### PR TITLE
Add runtime-aware media quality modes and Settings notice (web vs Local App)

### DIFF
--- a/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
+++ b/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# Calling Transport Architecture (Web Baseline + Tauri Enhanced)
+
+## Goals
+- Keep browser calls lightweight and reliable for self-hosted deployments.
+- Enable higher-quality transport/features for Tauri-native targets without breaking web compatibility.
+- Keep memory/CPU budgets low with graceful degradation.
+
+> Important: this document describes the target architecture. The current implementation only includes WebRTC-side tuning and Opus preference hints; it does **not** include a full SRT media gateway implementation yet.
+
+## Transport Modes
+
+### 1) Web Baseline (default)
+- Interactive calls use WebRTC (P2P + TURN fallback).
+- Audio codec preference is Opus when browser APIs support explicit codec preference.
+- Video and screen-share use conservative defaults to reduce RAM/CPU pressure.
+
+### 2) Tauri Enhanced (optional)
+- Tauri clients may enable native media enhancements via Rust-side capabilities.
+- Browser interoperability remains via WebRTC signaling path.
+
+### 3) SRT Gateway Mode (optional, self-hosted)
+- Browsers do not directly use SRT for interactive peer calls.
+- SRT is used between server-side media gateway components where needed:
+  - ingest/relay,
+  - recording,
+  - distribution pipelines.
+- Gateway must expose a control interface to app backend and preserve auth boundaries.
+
+### Current Status
+- ✅ WebRTC baseline improvements shipped (deafen/video-toggle fixes, sender tuning, Opus preference attempt).
+- ⚠️ SRT gateway not yet shipped (design only in this phase).
+
+## Operational Requirements (SRT Gateway)
+- Explicit ports/TLS config in deployment docs.
+- Per-stream auth and ACL rules.
+- Metrics: packet loss, jitter, RTT, bitrate, reconnection counts.
+- Fallback to pure WebRTC when gateway unavailable.
+
+## Rollout Tasks
+1. Fix call control bugs (deafen/video-on upgrade).
+2. Stabilize WebRTC sender tuning (Opus preference + bitrate caps).
+3. Add adaptive quality ladder (resolution/fps/bitrate).
+4. Introduce gateway control hooks for SRT mode (disabled by default).
+5. Add Tauri capability gates for enhanced mode.
+
+## Non-Goals
+- Replacing browser WebRTC call transport with direct SRT.
+- Forcing heavy transcoding on low-resource hosts by default.

--- a/frontend/src/lib/calling.ts
+++ b/frontend/src/lib/calling.ts
@@ -1,6 +1,19 @@
 import { writable, get } from 'svelte/store';
 import type { Socket } from 'socket.io-client';
 import { buildRTCConfig } from './turnConfig';
+import { getMediaRuntimeConfig } from './mediaRuntime';
+
+const CAMERA_CONSTRAINTS: MediaTrackConstraints = {
+	width: { ideal: 1280, max: 1920 },
+	height: { ideal: 720, max: 1080 },
+	frameRate: { ideal: 24, max: 30 }
+};
+
+const SCREEN_SHARE_CONSTRAINTS: MediaTrackConstraints = {
+	frameRate: { ideal: 12, max: 20 },
+	width: { ideal: 1920, max: 2560 },
+	height: { ideal: 1080, max: 1440 }
+};
 
 // ============================================================================
 // Types
@@ -44,6 +57,9 @@ interface PeerConnectionState {
 	iceCandidateQueue: RTCIceCandidateInit[];
 	hasRemoteDescription: boolean;
 }
+
+type SenderMediaKind = 'audio' | 'video';
+type VideoSource = 'camera' | 'screen-share';
 
 // ============================================================================
 // Stores
@@ -253,6 +269,77 @@ function createPeerConnection(
 	return pc;
 }
 
+function preferOpusForAudio(sender: RTCRtpSender, pc: RTCPeerConnection): void {
+	const transceiver = pc.getTransceivers().find(t => t.sender === sender);
+	if (!transceiver || typeof transceiver.setCodecPreferences !== 'function') {
+		return;
+	}
+
+	const capabilities = RTCRtpSender.getCapabilities?.('audio');
+	if (!capabilities?.codecs?.length) {
+		return;
+	}
+
+	const opusCodecs = capabilities.codecs.filter(codec => codec.mimeType.toLowerCase() === 'audio/opus');
+	if (!opusCodecs.length) {
+		return;
+	}
+
+	const otherCodecs = capabilities.codecs.filter(codec => codec.mimeType.toLowerCase() !== 'audio/opus');
+	transceiver.setCodecPreferences([...opusCodecs, ...otherCodecs]);
+}
+
+async function optimizeSender(sender: RTCRtpSender, pc: RTCPeerConnection, kind: SenderMediaKind, source: VideoSource = 'camera'): Promise<void> {
+	try {
+		if (kind === 'audio') {
+			preferOpusForAudio(sender, pc);
+		}
+
+		const params = sender.getParameters();
+		if (!params.encodings || params.encodings.length === 0) {
+			params.encodings = [{}];
+		}
+
+		const runtimeConfig = getMediaRuntimeConfig();
+
+		for (const encoding of params.encodings) {
+			if (kind === 'audio') {
+				encoding.maxBitrate = runtimeConfig.audioMaxBitrate;
+			} else {
+				encoding.maxBitrate = source === 'screen-share' ? runtimeConfig.screenShareMaxBitrate : runtimeConfig.videoMaxBitrate;
+				encoding.maxFramerate = source === 'screen-share' ? 18 : 24;
+				typeof encoding.scaleResolutionDownBy === 'number' || (encoding.scaleResolutionDownBy = 1);
+			}
+		}
+
+		await sender.setParameters(params);
+	} catch (error) {
+		console.warn('[WebRTC] Could not optimize sender parameters:', error);
+	}
+}
+
+async function addTrackWithOptimizations(pc: RTCPeerConnection, track: MediaStreamTrack, stream: MediaStream): Promise<void> {
+	const isScreenShareTrack = stream === get(localScreenStream);
+	if (track.kind === 'video') {
+		track.contentHint = isScreenShareTrack ? 'detail' : 'motion';
+	}
+
+	const sender = pc.addTrack(track, stream);
+	await optimizeSender(sender, pc, track.kind as SenderMediaKind, isScreenShareTrack ? 'screen-share' : 'camera');
+}
+
+async function renegotiateCallConnection(state: PeerConnectionState, socket: Socket): Promise<void> {
+	if (state.type !== 'call') return;
+
+	const offer = await state.pc.createOffer();
+	await state.pc.setLocalDescription(offer);
+
+	socket.emit('call-offer', {
+		offer,
+		targetId: state.targetId
+	});
+}
+
 function cleanupPeerConnection(key: string): void {
 	const state = peerConnections.get(key);
 	if (!state) return;
@@ -377,7 +464,7 @@ function updateRemoteTrackState(targetId: string, track: MediaStreamTrack, type:
 export async function startCall(socket: Socket, targetUserId: string, isVideoCall: boolean = false) {
 	try {
 		const stream = await navigator.mediaDevices.getUserMedia({
-			video: isVideoCall,
+			video: isVideoCall ? CAMERA_CONSTRAINTS : false,
 			audio: true
 		});
 		localStream.set(stream);
@@ -404,7 +491,7 @@ export async function startCall(socket: Socket, targetUserId: string, isVideoCal
 export async function answerCall(socket: Socket, callerId: string, isVideoCall: boolean = false) {
 	try {
 		const stream = await navigator.mediaDevices.getUserMedia({
-			video: isVideoCall,
+			video: isVideoCall ? CAMERA_CONSTRAINTS : false,
 			audio: true
 		});
 		localStream.set(stream);
@@ -502,14 +589,53 @@ export function toggleDeafen() {
 	// by setting audio elements to muted based on isDeafened store
 }
 
-export function toggleVideo() {
+export async function toggleVideo(socket?: Socket) {
 	const stream = get(localStream);
-	if (stream) {
-		const videoTrack = stream.getVideoTracks()[0];
-		if (videoTrack) {
-			videoTrack.enabled = !videoTrack.enabled;
-			isVideoOff.set(!videoTrack.enabled);
+	if (!stream) {
+		return;
+	}
+
+	const existingTrack = stream.getVideoTracks()[0];
+	if (existingTrack) {
+		existingTrack.enabled = !existingTrack.enabled;
+		isVideoOff.set(!existingTrack.enabled);
+		return;
+	}
+
+	try {
+		const cameraStream = await navigator.mediaDevices.getUserMedia({
+			video: CAMERA_CONSTRAINTS,
+			audio: false
+		});
+		const cameraTrack = cameraStream.getVideoTracks()[0];
+		if (!cameraTrack) {
+			return;
 		}
+
+		stream.addTrack(cameraTrack);
+
+		const renegotiationTasks: Promise<void>[] = [];
+		peerConnections.forEach(state => {
+			if (state.type !== 'call') return;
+
+			const existingSender = state.pc.getSenders().find(sender => sender.track?.kind === 'video');
+			if (existingSender) {
+				renegotiationTasks.push(existingSender.replaceTrack(cameraTrack));
+				renegotiationTasks.push(optimizeSender(existingSender, state.pc, 'video', 'camera'));
+			} else {
+				renegotiationTasks.push(addTrackWithOptimizations(state.pc, cameraTrack, stream));
+			}
+
+			if (socket) {
+				renegotiationTasks.push(renegotiateCallConnection(state, socket));
+			}
+		});
+
+		await Promise.all(renegotiationTasks);
+		isVideoOff.set(false);
+	} catch (error) {
+		console.error('[WebRTC] Could not enable camera track:', error);
+		handleMediaError(error as DOMException, 'starting');
 	}
 }
 
@@ -523,9 +649,9 @@ export async function createCallOffer(socket: Socket, targetId: string, username
 
 	const stream = get(localStream);
 	if (stream) {
-		stream.getTracks().forEach(track => {
-			pc.addTrack(track, stream);
-		});
+		for (const track of stream.getTracks()) {
+			await addTrackWithOptimizations(pc, track, stream);
+		}
 	}
 
 	try {
@@ -553,9 +679,9 @@ export async function handleCallOffer(
 
 	const stream = get(localStream);
 	if (stream) {
-		stream.getTracks().forEach(track => {
-			pc.addTrack(track, stream);
-		});
+		for (const track of stream.getTracks()) {
+			await addTrackWithOptimizations(pc, track, stream);
+		}
 	}
 
 	try {
@@ -610,7 +736,7 @@ export async function handleCallIceCandidate(senderId: string, candidate: RTCIce
 export async function startScreenShare(socket: Socket) {
 	try {
 		const stream = await navigator.mediaDevices.getDisplayMedia({
-			video: true,
+			video: SCREEN_SHARE_CONSTRAINTS,
 			audio: true
 		});
 
@@ -661,9 +787,9 @@ export async function createScreenShareOffer(socket: Socket, targetId: string) {
 
 	const stream = get(localScreenStream);
 	if (stream) {
-		stream.getTracks().forEach(track => {
-			pc.addTrack(track, stream);
-		});
+		for (const track of stream.getTracks()) {
+			await addTrackWithOptimizations(pc, track, stream);
+		}
 	}
 
 	try {

--- a/frontend/src/lib/components/CallModal.svelte
+++ b/frontend/src/lib/components/CallModal.svelte
@@ -206,8 +206,8 @@
 		toggleMute();
 	}
 
-	function handleToggleVideo() {
-		toggleVideo();
+	async function handleToggleVideo() {
+		await toggleVideo($socket || undefined);
 	}
 
 	async function handleToggleScreenShare() {
@@ -297,6 +297,7 @@
 							autoplay
 							playsinline
 							class="video-element"
+							muted={$isDeafened}
 							class:video-hidden={!call.isVideoEnabled}
 						></video>
 						{#if !call.isVideoEnabled}
@@ -325,7 +326,7 @@
 								class="tile-video tile-video-contain"
 								autoplay
 								playsinline
-								muted={tile.kind === 'local-screen'}
+								muted={tile.kind === 'local-screen' || (tile.userId !== null && $isDeafened)}
 								use:bindTileVideo={tile.stream}
 							></video>
 						{:else if tile.kind === 'video' || tile.kind === 'local-camera'}
@@ -334,7 +335,7 @@
 								class="tile-video"
 								autoplay
 								playsinline
-								muted={tile.userId === null}
+								muted={tile.userId === null || $isDeafened}
 								use:bindTileVideo={tile.stream}
 							></video>
 						{:else}
@@ -359,7 +360,7 @@
 								class="focused-video focused-video-contain"
 								autoplay
 								playsinline
-								muted={focusedTile.kind === 'local-screen'}
+								muted={focusedTile.kind === 'local-screen' || (focusedTile.userId !== null && $isDeafened)}
 								use:bindTileVideo={focusedTile.stream}
 							></video>
 						{:else if focusedTile.kind === 'video' || focusedTile.kind === 'local-camera'}
@@ -368,7 +369,7 @@
 								class="focused-video"
 								autoplay
 								playsinline
-								muted={focusedTile.userId === null}
+								muted={focusedTile.userId === null || $isDeafened}
 								use:bindTileVideo={focusedTile.stream}
 							></video>
 						{:else}
@@ -407,7 +408,7 @@
 										class="thumbnail-video"
 										autoplay
 										playsinline
-										muted={thumb.userId === null}
+										muted={thumb.userId === null || $isDeafened}
 										use:bindTileVideo={thumb.stream}
 									></video>
 								{:else}

--- a/frontend/src/lib/components/CallView.svelte
+++ b/frontend/src/lib/components/CallView.svelte
@@ -97,8 +97,9 @@
 		toggleDeafen();
 	}
 
-	function handleToggleVideo() {
-		toggleVideo();
+	async function handleToggleVideo() {
+		const sock = getSocket();
+		await toggleVideo(sock || undefined);
 	}
 
 	// Get initials for avatar

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { channelMessages, users, currentUser, emojis, updateProfile } from '$lib/socket';
 	import StorageSettings from './StorageSettings.svelte';
@@ -16,6 +17,14 @@
 	import ThemeCustomizer from './ThemeCustomizer.svelte';
 	import UsernameFontCustomizer from './UsernameFontCustomizer.svelte';
 	import UniformFontMode from './UniformFontMode.svelte';
+	import {
+		getStoredMediaQualityMode,
+		isSrtGatewayEnabled,
+		isTauriRuntime,
+		setMediaQualityMode,
+		setSrtGatewayEnabled,
+		type MediaQualityMode
+	} from '$lib/mediaRuntime';
 
 	const dispatch = createEventDispatcher();
 
@@ -27,6 +36,9 @@
 	let cameraEnabled = true;
 	let notificationSound = '/sounds/ProjectSound.ogg';
 	let notificationVolume = 0.5;
+	let mediaQualityMode: MediaQualityMode = 'web-baseline';
+	let srtGatewayEnabled = false;
+	let localAppRuntime = false;
 
 	// Theme saving state
 	let savingTheme = false;
@@ -61,6 +73,9 @@
 		cameraEnabled = localStorage.getItem('cameraEnabled') !== 'false';
 		notificationSound = localStorage.getItem('notificationSound') || '/sounds/ProjectSound.ogg';
 		notificationVolume = parseFloat(localStorage.getItem('notificationVolume') || '0.5');
+		localAppRuntime = isTauriRuntime();
+		mediaQualityMode = getStoredMediaQualityMode();
+		srtGatewayEnabled = isSrtGatewayEnabled();
 	});
 
 	function toggleSound() {
@@ -81,6 +96,17 @@
 	function toggleCamera() {
 		cameraEnabled = !cameraEnabled;
 		localStorage.setItem('cameraEnabled', cameraEnabled.toString());
+	}
+
+	function updateMediaQualityMode(mode: MediaQualityMode) {
+		mediaQualityMode = mode;
+		setMediaQualityMode(mode);
+	}
+
+	function toggleSrtGateway() {
+		if (!localAppRuntime) return;
+		srtGatewayEnabled = !srtGatewayEnabled;
+		setSrtGatewayEnabled(srtGatewayEnabled);
 	}
 
 	// Handle theme change
@@ -587,11 +613,48 @@
 							<span class="setting-label">Camera</span>
 							<span class="setting-description">Enable camera for video calls</span>
 						</div>
-						<button class="toggle-btn" class:active={cameraEnabled} on:click={toggleCamera}>
-							{cameraEnabled ? '📹' : '📷'}
+					<button class="toggle-btn" class:active={cameraEnabled} on:click={toggleCamera}>
+						{cameraEnabled ? '📹' : '📷'}
+					</button>
+				</div>
+				<div class="media-quality-notice" role="note">
+					<div class="notice-title">Call Quality Runtime Notice</div>
+					<div class="notice-body">
+						{#if localAppRuntime}
+							You are running the Local App runtime. Enhanced audio/video tuning is available, including optional SRT gateway controls.
+						{:else}
+							You are running Web runtime. Calls use compatibility-first media settings. For best audio quality, use the Local App.
+						{/if}
+					</div>
+
+					<div class="quality-mode-row">
+						<label for="media-quality-mode">Media Quality Mode</label>
+						<select
+							id="media-quality-mode"
+							class="theme-select"
+							value={mediaQualityMode}
+							on:change={(e) => updateMediaQualityMode(e.currentTarget.value as MediaQualityMode)}
+						>
+							<option value="web-baseline">Web Baseline</option>
+							<option value="local-enhanced" disabled={!localAppRuntime}>Local App Enhanced</option>
+						</select>
+					</div>
+
+					<div class="setting-item">
+						<div class="setting-info">
+							<span class="setting-label">SRT Gateway (Beta)</span>
+							<span class="setting-description">Requires Local App + self-hosted media gateway. Browser-only calls do not use SRT directly.</span>
+						</div>
+						<button class="toggle-btn" class:active={srtGatewayEnabled} on:click={toggleSrtGateway} disabled={!localAppRuntime}>
+							{srtGatewayEnabled ? 'ON' : 'OFF'}
 						</button>
 					</div>
+
+					{#if !localAppRuntime && browser}
+						<p class="runtime-note">Tip: install the Local App (Tauri) to unlock enhanced call quality mode.</p>
+					{/if}
 				</div>
+			</div>
 
 				<!-- Notifications -->
 				<div class="settings-section">
@@ -1174,8 +1237,49 @@
 		margin-top: 1rem !important;
 	}
 
-	/* Notification Sound Settings */
-	.setting-item-full {
+	.media-quality-notice {
+		margin-top: 1rem;
+		padding: 0.9rem;
+		border-radius: 8px;
+		border: 1px solid rgba(var(--accent-rgb), 0.25);
+		background: rgba(var(--accent-rgb), 0.08);
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	.notice-title {
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.notice-body {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		line-height: 1.4;
+	}
+
+	.quality-mode-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.quality-mode-row label {
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.runtime-note {
+		margin: 0;
+		font-size: 0.78rem;
+		color: var(--text-tertiary);
+	}
+
+		/* Notification Sound Settings */
+		.setting-item-full {
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;

--- a/frontend/src/lib/mediaRuntime.ts
+++ b/frontend/src/lib/mediaRuntime.ts
@@ -1,0 +1,80 @@
+import { browser } from '$app/environment';
+
+export type MediaQualityMode = 'web-baseline' | 'local-enhanced';
+
+export interface MediaRuntimeConfig {
+	isTauri: boolean;
+	qualityMode: MediaQualityMode;
+	enableSrtGateway: boolean;
+	audioMaxBitrate: number;
+	videoMaxBitrate: number;
+	screenShareMaxBitrate: number;
+}
+
+const STORAGE_KEYS = {
+	qualityMode: 'wabi_media_quality_mode',
+	srtGateway: 'wabi_enable_srt_gateway'
+};
+
+export function isTauriRuntime(): boolean {
+	if (!browser) return false;
+	return Boolean((window as Window & { __TAURI_CORE__?: unknown }).__TAURI_CORE__);
+}
+
+function resolveQualityMode(isTauri: boolean): MediaQualityMode {
+	if (!browser) {
+		return 'web-baseline';
+	}
+
+	const stored = localStorage.getItem(STORAGE_KEYS.qualityMode);
+	if (stored === 'web-baseline' || stored === 'local-enhanced') {
+		return stored;
+	}
+
+	return isTauri ? 'local-enhanced' : 'web-baseline';
+}
+
+export function getMediaRuntimeConfig(): MediaRuntimeConfig {
+	const isTauri = isTauriRuntime();
+	const qualityMode = resolveQualityMode(isTauri);
+	const enableSrtGateway = browser && localStorage.getItem(STORAGE_KEYS.srtGateway) === 'true';
+
+	if (qualityMode === 'local-enhanced') {
+		return {
+			isTauri,
+			qualityMode,
+			enableSrtGateway,
+			audioMaxBitrate: 96000,
+			videoMaxBitrate: 2_200_000,
+			screenShareMaxBitrate: 2_600_000
+		};
+	}
+
+	return {
+		isTauri,
+		qualityMode,
+		enableSrtGateway,
+		audioMaxBitrate: 64000,
+		videoMaxBitrate: 1_200_000,
+		screenShareMaxBitrate: 1_600_000
+	};
+}
+
+export function setMediaQualityMode(mode: MediaQualityMode): void {
+	if (!browser) return;
+	localStorage.setItem(STORAGE_KEYS.qualityMode, mode);
+}
+
+export function setSrtGatewayEnabled(enabled: boolean): void {
+	if (!browser) return;
+	localStorage.setItem(STORAGE_KEYS.srtGateway, String(enabled));
+}
+
+export function getStoredMediaQualityMode(): MediaQualityMode {
+	return resolveQualityMode(isTauriRuntime());
+}
+
+export function isSrtGatewayEnabled(): boolean {
+	if (!browser) return false;
+	return localStorage.getItem(STORAGE_KEYS.srtGateway) === 'true';
+}


### PR DESCRIPTION
### Motivation
- Surface the difference in audio/video quality between Web and the Local App (Tauri) and provide user controls for future Opus/SRT enhancements.
- Prepare the frontend signaling and sender tuning so the app can opt into higher bitrate/resolution profiles when running as a Local App.
- Gate SRT-related controls to the Local App runtime while keeping browser calls compatibility-first.

### Description
- Add a new runtime module `frontend/src/lib/mediaRuntime.ts` that detects Tauri vs browser runtime, persists a `MediaQualityMode`, and exposes bitrate profiles and SRT toggle helpers.
- Wire runtime-aware sender tuning in `frontend/src/lib/calling.ts`: prefer Opus for audio, add `optimizeSender`/`addTrackWithOptimizations`, and read bitrate caps from `getMediaRuntimeConfig()` (separate tiers for audio, video, and screen-share); also make camera/renegotiation behavior async and safer when enabling video.
- Add Settings UI updates in `frontend/src/lib/components/Settings.svelte` to display a clear runtime notice, a `Media Quality Mode` selector, and an `SRT Gateway (Beta)` toggle (persisted to localStorage and gated to Local App runtime).
- Improve in-call behavior: `CallModal.svelte` and `CallView.svelte` now consider `isDeafened` when muting remote video/audio elements so deafen behaves as expected.
- Add design documentation `PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md` describing Web Baseline vs Tauri Enhanced goals and current status.

### Testing
- Created a local commit with the changes via `git commit` which succeeded and includes the added `mediaRuntime.ts` and modifications to `calling.ts` and `Settings.svelte` (commit present locally). ✅
- Verified file diffs and touched locations with `git diff`, `rg`, and `nl` to confirm the expected edits were applied. ✅
- Attempted to run the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173`, which failed because `vite` is not available in this environment. ⚠️
- Attempted to push the branch but `git push`/`git push origin HEAD` failed because no remote is configured in this environment. ⚠️

If you want, I can continue by scaffolding the Tauri-side Rust hooks for Opus/SRT and the gateway integration, or prepare an artifact/branch ready for your CI to build and run the frontend dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699003fc08cc832aa7c7ad4bdc4d9f87)