### PR TITLE
Add configurable screen share resolution presets

### DIFF
--- a/frontend/src/lib/calling.ts
+++ b/frontend/src/lib/calling.ts
@@ -1,18 +1,12 @@
 import { writable, get } from 'svelte/store';
 import type { Socket } from 'socket.io-client';
 import { buildRTCConfig } from './turnConfig';
-import { getMediaRuntimeConfig } from './mediaRuntime';
+import { getMediaRuntimeConfig, getScreenShareQualityProfile } from './mediaRuntime';
 
 const CAMERA_CONSTRAINTS: MediaTrackConstraints = {
 	width: { ideal: 1280, max: 1920 },
 	height: { ideal: 720, max: 1080 },
 	frameRate: { ideal: 24, max: 30 }
-};
-
-const SCREEN_SHARE_CONSTRAINTS: MediaTrackConstraints = {
-	frameRate: { ideal: 12, max: 20 },
-	width: { ideal: 1920, max: 2560 },
-	height: { ideal: 1080, max: 1440 }
 };
 
 // ============================================================================
@@ -306,8 +300,9 @@ async function optimizeSender(sender: RTCRtpSender, pc: RTCPeerConnection, kind:
 			if (kind === 'audio') {
 				encoding.maxBitrate = runtimeConfig.audioMaxBitrate;
 			} else {
-				encoding.maxBitrate = source === 'screen-share' ? runtimeConfig.screenShareMaxBitrate : runtimeConfig.videoMaxBitrate;
-				encoding.maxFramerate = source === 'screen-share' ? 18 : 24;
+				const screenShareQuality = getScreenShareQualityProfile();
+				encoding.maxBitrate = source === 'screen-share' ? Math.min(runtimeConfig.screenShareMaxBitrate, screenShareQuality.maxBitrate) : runtimeConfig.videoMaxBitrate;
+				encoding.maxFramerate = source === 'screen-share' ? screenShareQuality.maxFramerate : 24;
 				typeof encoding.scaleResolutionDownBy === 'number' || (encoding.scaleResolutionDownBy = 1);
 			}
 		}
@@ -735,8 +730,9 @@ export async function handleCallIceCandidate(senderId: string, candidate: RTCIce
 
 export async function startScreenShare(socket: Socket) {
 	try {
+		const screenShareQuality = getScreenShareQualityProfile();
 		const stream = await navigator.mediaDevices.getDisplayMedia({
-			video: SCREEN_SHARE_CONSTRAINTS,
+			video: screenShareQuality.constraints,
 			audio: true
 		});
 

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -19,12 +19,15 @@
 	import UniformFontMode from './UniformFontMode.svelte';
 	import {
 		getStoredMediaQualityMode,
+		getStoredScreenShareQualityPreset,
 		isSrtGatewayEnabled,
 		isTauriRuntime,
 		setMediaQualityMode,
+		setScreenShareQualityPreset,
 		setSrtGatewayEnabled,
 		syncMediaRuntimeFromServer,
-		type MediaQualityMode
+		type MediaQualityMode,
+		type ScreenShareQualityPreset
 	} from '$lib/mediaRuntime';
 
 	const dispatch = createEventDispatcher();
@@ -39,6 +42,7 @@
 	let notificationVolume = 0.5;
 	let mediaQualityMode: MediaQualityMode = 'web-baseline';
 	let srtGatewayEnabled = false;
+	let screenShareQualityPreset: ScreenShareQualityPreset = 'auto';
 	let localAppRuntime = false;
 
 	// Theme saving state
@@ -82,6 +86,7 @@
 			// After server sync, load local settings (will be constrained if needed)
 			mediaQualityMode = getStoredMediaQualityMode();
 			srtGatewayEnabled = isSrtGatewayEnabled();
+			screenShareQualityPreset = getStoredScreenShareQualityPreset();
 		})();
 	});
 
@@ -114,6 +119,11 @@
 		if (!localAppRuntime) return;
 		srtGatewayEnabled = !srtGatewayEnabled;
 		setSrtGatewayEnabled(srtGatewayEnabled);
+	}
+
+	function updateScreenShareQualityPreset(preset: ScreenShareQualityPreset) {
+		screenShareQualityPreset = preset;
+		setScreenShareQualityPreset(preset);
 	}
 
 	// Handle theme change
@@ -644,6 +654,22 @@
 						>
 							<option value="web-baseline">Web Baseline</option>
 							<option value="local-enhanced" disabled={!localAppRuntime}>Local App Enhanced</option>
+						</select>
+					</div>
+
+					<div class="quality-mode-row">
+						<label for="screen-share-quality">Screen Share Resolution</label>
+						<select
+							id="screen-share-quality"
+							class="theme-select"
+							value={screenShareQualityPreset}
+							on:change={(e) => updateScreenShareQualityPreset(e.currentTarget.value as ScreenShareQualityPreset)}
+						>
+							<option value="auto">Auto (Recommended)</option>
+							<option value="1080p">1080p</option>
+							<option value="720p">720p</option>
+							<option value="480p">480p</option>
+							<option value="144p-mobile">144p (Mobile / Low data)</option>
 						</select>
 					</div>
 

--- a/frontend/src/lib/mediaRuntime.ts
+++ b/frontend/src/lib/mediaRuntime.ts
@@ -2,6 +2,14 @@ import { browser } from '$app/environment';
 import { getServerUrl } from './serverUrl';
 
 export type MediaQualityMode = 'web-baseline' | 'local-enhanced';
+export type ScreenShareQualityPreset = 'auto' | '1080p' | '720p' | '480p' | '144p-mobile';
+
+export interface ScreenShareQualityProfile {
+	label: string;
+	constraints: MediaTrackConstraints;
+	maxBitrate: number;
+	maxFramerate: number;
+}
 
 export interface ServerMediaRuntimeResponse {
 	media?: {
@@ -34,7 +42,61 @@ export interface MediaRuntimeConfig {
 
 const STORAGE_KEYS = {
 	qualityMode: 'wabi_media_quality_mode',
-	srtGateway: 'wabi_enable_srt_gateway'
+	srtGateway: 'wabi_enable_srt_gateway',
+	screenShareQuality: 'wabi_screen_share_quality_preset'
+};
+
+const SCREEN_SHARE_QUALITY_PROFILES: Record<ScreenShareQualityPreset, ScreenShareQualityProfile> = {
+	auto: {
+		label: 'Auto (Recommended)',
+		constraints: {
+			frameRate: { ideal: 12, max: 20 },
+			width: { ideal: 1920, max: 2560 },
+			height: { ideal: 1080, max: 1440 }
+		},
+		maxBitrate: 1_600_000,
+		maxFramerate: 18
+	},
+	'1080p': {
+		label: '1080p',
+		constraints: {
+			frameRate: { ideal: 15, max: 24 },
+			width: { ideal: 1920, max: 1920 },
+			height: { ideal: 1080, max: 1080 }
+		},
+		maxBitrate: 2_200_000,
+		maxFramerate: 24
+	},
+	'720p': {
+		label: '720p',
+		constraints: {
+			frameRate: { ideal: 12, max: 20 },
+			width: { ideal: 1280, max: 1280 },
+			height: { ideal: 720, max: 720 }
+		},
+		maxBitrate: 1_200_000,
+		maxFramerate: 20
+	},
+	'480p': {
+		label: '480p',
+		constraints: {
+			frameRate: { ideal: 10, max: 15 },
+			width: { ideal: 854, max: 854 },
+			height: { ideal: 480, max: 480 }
+		},
+		maxBitrate: 700_000,
+		maxFramerate: 15
+	},
+	'144p-mobile': {
+		label: '144p (Mobile/Low Data)',
+		constraints: {
+			frameRate: { ideal: 8, max: 12 },
+			width: { ideal: 256, max: 256 },
+			height: { ideal: 144, max: 144 }
+		},
+		maxBitrate: 180_000,
+		maxFramerate: 12
+	}
 };
 
 export function isTauriRuntime(): boolean {
@@ -89,6 +151,25 @@ export function setMediaQualityMode(mode: MediaQualityMode): void {
 export function setSrtGatewayEnabled(enabled: boolean): void {
 	if (!browser) return;
 	localStorage.setItem(STORAGE_KEYS.srtGateway, String(enabled));
+}
+
+export function getStoredScreenShareQualityPreset(): ScreenShareQualityPreset {
+	if (!browser) return 'auto';
+	const stored = localStorage.getItem(STORAGE_KEYS.screenShareQuality);
+	if (stored && stored in SCREEN_SHARE_QUALITY_PROFILES) {
+		return stored as ScreenShareQualityPreset;
+	}
+	return 'auto';
+}
+
+export function setScreenShareQualityPreset(preset: ScreenShareQualityPreset): void {
+	if (!browser) return;
+	localStorage.setItem(STORAGE_KEYS.screenShareQuality, preset);
+}
+
+export function getScreenShareQualityProfile(): ScreenShareQualityProfile {
+	const preset = getStoredScreenShareQualityPreset();
+	return SCREEN_SHARE_QUALITY_PROFILES[preset];
 }
 
 export function getStoredMediaQualityMode(): MediaQualityMode {


### PR DESCRIPTION
### Motivation
- Provide explicit, user-selectable screen share quality options so users on weak networks (including mobile) can lower capture resolution/bitrate (e.g., 720p, 480p, 144p). 

### Description
- Add persistent screen-share presets and profiles in `frontend/src/lib/mediaRuntime.ts` with per-preset `MediaTrackConstraints`, `maxBitrate`, and `maxFramerate` for `auto`, `1080p`, `720p`, `480p`, and `144p-mobile`.
- Use the selected preset when calling `navigator.mediaDevices.getDisplayMedia` and when tuning `RTCRtpSender` parameters so capture constraints and sender bitrate/framerate honor the chosen profile in `frontend/src/lib/calling.ts`.
- Expose getters/setters for the preset and a helper `getScreenShareQualityProfile()` and persist the choice to `localStorage` under `wabi_screen_share_quality_preset` in `mediaRuntime.ts`.
- Add a new `Screen Share Resolution` dropdown to the Settings UI and wire the setting to the runtime using `frontend/src/lib/components/Settings.svelte` so users can change and persist their preference.

### Testing
- Ran `npm --prefix frontend run check` which reported repository-wide TypeScript/Svelte diagnostics and therefore failed, but these failures are pre-existing and unrelated to the screen-share preset changes.
- Started the frontend dev server with `npm --prefix frontend run dev` which launched successfully and served the updated Settings UI.
- Automated UI verification via a Playwright script that opened the running dev server and saved a screenshot of the updated Settings page, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69902e73bb0c832a9b77a85000b75cb4)