### PR TITLE
Fix channel sidebar alignment and restore channel header descriptions

### DIFF
--- a/frontend/src/lib/components/ChannelSidebar.svelte
+++ b/frontend/src/lib/components/ChannelSidebar.svelte
@@ -35,6 +35,7 @@
 
 	// Sidebar width from layout store - 3 modes: normal (280px), compact (60px), hidden (0px)
 	$: sidebarWidth = $layoutStore.channelSidebarWidth;
+	$: isCompactSidebar = sidebarWidth === 60;
 
 	// Context menu state
 	let contextMenuChannel: Channel | null = null;
@@ -184,7 +185,7 @@
 	<button class="expand-btn" on:click={toggleSidebar} title="Expand sidebar">›</button>
 {/if}
 
-<div class="channel-sidebar" style="width: {$layoutStore.channelSidebarWidth}px">
+<div class="channel-sidebar" class:compact={isCompactSidebar} style="width: {$layoutStore.channelSidebarWidth}px">
 	<div class="top-section">
 		<button class="mobile-close-btn" on:click={() => dispatch('close')}>&times;</button>
 		<div class="logo">
@@ -614,20 +615,20 @@
 	}
 
 	/* Compact mode: show only letters */
-	.channel-sidebar[style*="width: 60px"] .logo-img {
+	.channel-sidebar.compact .logo-img {
 		height: 24px;
 		width: auto;
 	}
 
-	.channel-sidebar[style*="width: 60px"] .sidebar-header,
-	.channel-sidebar[style*="width: 60px"] .profile-card .user-details,
-	.channel-sidebar[style*="width: 60px"] .profile-controls,
-	.channel-sidebar[style*="width: 60px"] .status-popup,
-	.channel-sidebar[style*="width: 60px"] .create-channel {
+	.channel-sidebar.compact .sidebar-header,
+	.channel-sidebar.compact .profile-card .user-details,
+	.channel-sidebar.compact .profile-controls,
+	.channel-sidebar.compact .status-popup,
+	.channel-sidebar.compact .create-channel {
 		display: none;
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-btn {
+	.channel-sidebar.compact .channel-btn {
 		font-size: 0;
 		justify-content: center;
 		position: relative;
@@ -635,29 +636,29 @@
 		height: 100%;
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-btn::after {
+	.channel-sidebar.compact .channel-btn::after {
 		content: attr(data-abbrev);
 		font-size: 0.8rem;
 		font-weight: 600;
 		color: var(--text-secondary);
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-item.active .channel-btn::after {
+	.channel-sidebar.compact .channel-item.active .channel-btn::after {
 		color: var(--text-primary);
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-btn .hash,
-	.channel-sidebar[style*="width: 60px"] .channel-btn .group-icon {
+	.channel-sidebar.compact .channel-btn .hash,
+	.channel-sidebar.compact .channel-btn .group-icon {
 		font-size: 1rem;
 		margin: 0;
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-item {
+	.channel-sidebar.compact .channel-item {
 		justify-content: center;
 		padding: 0.25rem;
 	}
 
-	.channel-sidebar[style*="width: 60px"] .channel-actions {
+	.channel-sidebar.compact .channel-actions {
 		display: none;
 	}
 
@@ -868,12 +869,12 @@
 		flex-direction: column;
 		flex: 1;
 		overflow-y: auto;
-		padding: 0.5rem 0;
+		padding: 0;
 	}
 
 	.channel-item {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		padding: 0 0.5rem;
 		position: relative;
 	}
@@ -898,6 +899,7 @@
 		transition: all 0.2s;
 		min-width: 0; /* Allows text to shrink and ellipsis */
 		height: fit-content;
+		justify-content: flex-start;
 	}
 
 	.channel-item.active .channel-btn {
@@ -1229,7 +1231,7 @@
 	}
 
 	/* Compact mode: maintain red indicator */
-	.channel-sidebar[style*="width: 60px"] .channel-item.has-timer {
+	.channel-sidebar.compact .channel-item.has-timer {
 		border-radius: 0;
 	}
 

--- a/frontend/src/lib/components/Chat.svelte
+++ b/frontend/src/lib/components/Chat.svelte
@@ -21,6 +21,7 @@
 	$: pinnedMessages = messages.filter((m: Message) => m.isPinned);
 	$: currentChannelData = $channels.find(ch => ch.id === $currentChannel);
 	$: channelDisplayName = currentChannelData?.name || $currentChannel;
+	$: channelDescription = currentChannelData?.description?.trim() || '';
 
 	// Safeguard: DM channels should never be displayed in the main chat area
 	// They should only appear in the DM panel on the right side
@@ -940,9 +941,11 @@
 
 	<div class="chat-header" class:dm-channel={isDMChannel}>
 		<h2>
-			{channelDisplayName}
+			<span class="channel-title">{channelDisplayName}</span>
 			{#if isDMChannel}
 				<span class="dm-badge">Direct Message</span>
+			{:else if channelDescription}
+				<span class="channel-description">{channelDescription}</span>
 			{/if}
 		</h2>
 		<div class="search-container">
@@ -1197,8 +1200,25 @@
 		font-weight: var(--font-weight-semibold);
 		flex: 1;
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		gap: 0.5rem;
+		min-width: 0;
+	}
+
+	.channel-title {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.channel-description {
+		font-size: var(--text-sm);
+		font-weight: var(--font-weight-regular);
+		color: var(--text-secondary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.dm-badge {


### PR DESCRIPTION
### Motivation
- Channels were visually misaligned and sometimes appeared centered instead of flush left in the channel sidebar, producing a grid misalignment with the main chat area. 
- Compact sidebar behavior depended on matching inline `style` strings which is brittle and caused layout drift. 
- The active channel header was missing the channel description text that lives on channel metadata, reducing contextual information in the chat header.

### Description
- Added a reactive `isCompactSidebar` flag and bound `class:compact` on the sidebar container so compact styles are driven by state rather than fragile inline `style` matching, and replaced compact CSS selectors to use `.channel-sidebar.compact` instead of `[style*="width: 60px"]` (changed `frontend/src/lib/components/ChannelSidebar.svelte`).
- Tightened list layout by removing extra padding on `.channel-list`, aligning `.channel-item` vertically (`align-items: center`) and ensuring channel buttons left-align with `justify-content: flex-start` so rows line up with the header boundary (changed `frontend/src/lib/components/ChannelSidebar.svelte`).
- Restored rendering of channel descriptions in the chat header by deriving `channelDescription` from channel metadata and rendering a `.channel-description` element next to the channel title when not in DM mode (changed `frontend/src/lib/components/Chat.svelte`).
- Added safe truncation/overflow rules for long channel names and descriptions to keep header layout stable (`.channel-title` and `.channel-description` styles added in `frontend/src/lib/components/Chat.svelte`).

### Testing
- Ran `npm run check` in `frontend`, which completed but reported pre-existing TypeScript/Svelte diagnostics unrelated to these changes (the command did not pass cleanly due to repo-wide issues). 
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully for manual verification. 
- Captured a Playwright screenshot of the running app at `http://127.0.0.1:4173/` to validate the updated sidebar/header appearance (screenshot artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69903279003c832a864e939143457764)