### PR TITLE
Add core webhook support and wire plugin lifecycle event triggers

### DIFF
--- a/backend/src/api/webhookRoutes.ts
+++ b/backend/src/api/webhookRoutes.ts
@@ -1,0 +1,175 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import crypto from 'crypto';
+import { verifyToken } from '../auth/jwt.js';
+import { sessionRepository } from '../db/repositories/sessionRepository.js';
+import { webhookRepository } from '../db/repositories/webhookRepository.js';
+import { WEBHOOK_EVENTS } from '../webhooks/deliveryService.js';
+
+function getAuthenticatedUserId(req: IncomingMessage): number | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  try {
+    const token = authHeader.slice(7);
+    const payload = verifyToken(token);
+    const dbSession = sessionRepository.findById(payload.sessionId);
+    if (!dbSession || (dbSession.expires_at && dbSession.expires_at < Date.now())) {
+      return null;
+    }
+    return payload.userId;
+  } catch {
+    return null;
+  }
+}
+
+function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: Record<string, any>) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export async function handleCreateWebhook(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    writeJson(res, 401, { success: false, error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const body = await parseBody(req);
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    const targetUrl = typeof body.targetUrl === 'string' ? body.targetUrl.trim() : '';
+    const requestedEvents = Array.isArray(body.events) ? body.events : [];
+
+    if (!name || !targetUrl) {
+      writeJson(res, 400, { success: false, error: 'name and targetUrl are required' });
+      return;
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(targetUrl);
+    } catch {
+      writeJson(res, 400, { success: false, error: 'targetUrl must be a valid URL' });
+      return;
+    }
+
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      writeJson(res, 400, { success: false, error: 'targetUrl protocol must be http or https' });
+      return;
+    }
+
+    const events = requestedEvents
+      .filter((event: unknown): event is string => typeof event === 'string')
+      .filter((event) => WEBHOOK_EVENTS.includes(event as any));
+
+    if (events.length === 0) {
+      writeJson(res, 400, { success: false, error: `events must include at least one of: ${WEBHOOK_EVENTS.join(', ')}` });
+      return;
+    }
+
+    const secret = crypto.randomBytes(24).toString('hex');
+    const id = webhookRepository.create(userId, {
+      name,
+      target_url: parsedUrl.toString(),
+      secret,
+      event_filters: events,
+      enabled: 1
+    });
+
+    writeJson(res, 201, {
+      success: true,
+      webhook: {
+        id,
+        name,
+        targetUrl: parsedUrl.toString(),
+        events,
+        enabled: true,
+        secret
+      }
+    });
+  } catch (error) {
+    writeJson(res, 400, { success: false, error: error instanceof Error ? error.message : 'Invalid request' });
+  }
+}
+
+export async function handleListWebhooks(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    writeJson(res, 401, { success: false, error: 'Unauthorized' });
+    return;
+  }
+
+  const webhooks = webhookRepository.listByUser(userId).map((webhook) => ({
+    id: webhook.id,
+    name: webhook.name,
+    targetUrl: webhook.target_url,
+    events: JSON.parse(webhook.event_filters),
+    enabled: webhook.enabled === 1,
+    createdAt: webhook.created_at,
+    updatedAt: webhook.updated_at
+  }));
+
+  writeJson(res, 200, { success: true, webhooks });
+}
+
+export async function handleDeleteWebhook(req: IncomingMessage, res: ServerResponse, webhookId: number): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    writeJson(res, 401, { success: false, error: 'Unauthorized' });
+    return;
+  }
+
+  const deleted = webhookRepository.delete(webhookId, userId);
+  if (!deleted) {
+    writeJson(res, 404, { success: false, error: 'Webhook not found' });
+    return;
+  }
+
+  writeJson(res, 200, { success: true });
+}
+
+export async function handleListWebhookDeliveries(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) {
+    writeJson(res, 401, { success: false, error: 'Unauthorized' });
+    return;
+  }
+
+  const deliveries = webhookRepository.listDeliveriesForUser(userId).map((delivery) => ({
+    id: delivery.id,
+    webhookId: delivery.webhook_id,
+    webhookName: delivery.webhook_name,
+    eventType: delivery.event_type,
+    status: delivery.status,
+    attemptCount: delivery.attempt_count,
+    responseCode: delivery.response_code,
+    lastError: delivery.last_error,
+    createdAt: delivery.created_at,
+    updatedAt: delivery.updated_at,
+    deliveredAt: delivery.delivered_at
+  }));
+
+  writeJson(res, 200, { success: true, deliveries });
+}

--- a/backend/src/api/webhookRoutes.ts
+++ b/backend/src/api/webhookRoutes.ts
@@ -82,10 +82,10 @@ export async function handleCreateWebhook(req: IncomingMessage, res: ServerRespo
 
     const events = requestedEvents
       .filter((event: unknown): event is string => typeof event === 'string')
-      .filter((event) => WEBHOOK_EVENTS.includes(event as any));
+      .filter((event) => event === '*' || WEBHOOK_EVENTS.includes(event as any));
 
     if (events.length === 0) {
-      writeJson(res, 400, { success: false, error: `events must include at least one of: ${WEBHOOK_EVENTS.join(', ')}` });
+      writeJson(res, 400, { success: false, error: `events must include '*' or one of: ${WEBHOOK_EVENTS.join(', ')}` });
       return;
     }
 

--- a/backend/src/db/repositories/webhookRepository.ts
+++ b/backend/src/db/repositories/webhookRepository.ts
@@ -57,19 +57,14 @@ export class WebhookRepository {
     const stmt = db.prepare('SELECT * FROM webhooks WHERE user_id = ? ORDER BY created_at DESC');
     return stmt.all(userId) as Webhook[];
   }
-
-  listEnabledByEvent(eventType: string): Webhook[] {
+  listEnabled(): Webhook[] {
     const stmt = db.prepare(`
       SELECT * FROM webhooks
       WHERE enabled = 1
-        AND (
-          event_filters LIKE '%"*"%'
-          OR event_filters LIKE ?
-        )
       ORDER BY created_at DESC
     `);
 
-    return stmt.all(`%"${eventType}"%`) as Webhook[];
+    return stmt.all() as Webhook[];
   }
 
   delete(id: number, userId: number): boolean {
@@ -89,18 +84,30 @@ export class WebhookRepository {
     return result.lastInsertRowid as number;
   }
 
-  markDeliverySuccess(deliveryId: number, responseCode: number): void {
+  markDeliveryAttempt(deliveryId: number, attemptCount: number): void {
+    const now = Date.now();
+    const stmt = db.prepare(`
+      UPDATE webhook_deliveries
+      SET attempt_count = ?,
+          updated_at = ?
+      WHERE id = ?
+    `);
+    stmt.run(attemptCount, now, deliveryId);
+  }
+
+  markDeliverySuccess(deliveryId: number, responseCode: number, attemptCount: number = 1): void {
     const now = Date.now();
     const stmt = db.prepare(`
       UPDATE webhook_deliveries
       SET status = 'success',
+          attempt_count = ?,
           response_code = ?,
           last_error = NULL,
           updated_at = ?,
           delivered_at = ?
       WHERE id = ?
     `);
-    stmt.run(responseCode, now, now, deliveryId);
+    stmt.run(attemptCount, responseCode, now, now, deliveryId);
   }
 
   markDeliveryFailure(deliveryId: number, attemptCount: number, error: string, responseCode?: number): void {

--- a/backend/src/db/repositories/webhookRepository.ts
+++ b/backend/src/db/repositories/webhookRepository.ts
@@ -1,0 +1,133 @@
+import db from '../database.js';
+
+export interface Webhook {
+  id: number;
+  user_id: number;
+  name: string;
+  target_url: string;
+  secret: string;
+  event_filters: string;
+  enabled: number;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface WebhookDelivery {
+  id: number;
+  webhook_id: number;
+  event_type: string;
+  payload_json: string;
+  status: 'pending' | 'success' | 'failed';
+  attempt_count: number;
+  last_error: string | null;
+  response_code: number | null;
+  created_at: number;
+  updated_at: number;
+  delivered_at: number | null;
+}
+
+export class WebhookRepository {
+  create(userId: number, data: { name: string; target_url: string; secret: string; event_filters: string[]; enabled?: number }): number {
+    const now = Date.now();
+    const stmt = db.prepare(`
+      INSERT INTO webhooks (user_id, name, target_url, secret, event_filters, enabled, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      userId,
+      data.name,
+      data.target_url,
+      data.secret,
+      JSON.stringify(data.event_filters),
+      data.enabled ?? 1,
+      now,
+      now
+    );
+
+    return result.lastInsertRowid as number;
+  }
+
+  findById(id: number): Webhook | null {
+    const stmt = db.prepare('SELECT * FROM webhooks WHERE id = ?');
+    return (stmt.get(id) as Webhook) || null;
+  }
+
+  listByUser(userId: number): Webhook[] {
+    const stmt = db.prepare('SELECT * FROM webhooks WHERE user_id = ? ORDER BY created_at DESC');
+    return stmt.all(userId) as Webhook[];
+  }
+
+  listEnabledByEvent(eventType: string): Webhook[] {
+    const stmt = db.prepare(`
+      SELECT * FROM webhooks
+      WHERE enabled = 1
+        AND (
+          event_filters LIKE '%"*"%'
+          OR event_filters LIKE ?
+        )
+      ORDER BY created_at DESC
+    `);
+
+    return stmt.all(`%"${eventType}"%`) as Webhook[];
+  }
+
+  delete(id: number, userId: number): boolean {
+    const stmt = db.prepare('DELETE FROM webhooks WHERE id = ? AND user_id = ?');
+    const result = stmt.run(id, userId);
+    return result.changes > 0;
+  }
+
+  createDelivery(data: { webhook_id: number; event_type: string; payload_json: string }): number {
+    const now = Date.now();
+    const stmt = db.prepare(`
+      INSERT INTO webhook_deliveries (webhook_id, event_type, payload_json, status, attempt_count, created_at, updated_at)
+      VALUES (?, ?, ?, 'pending', 0, ?, ?)
+    `);
+
+    const result = stmt.run(data.webhook_id, data.event_type, data.payload_json, now, now);
+    return result.lastInsertRowid as number;
+  }
+
+  markDeliverySuccess(deliveryId: number, responseCode: number): void {
+    const now = Date.now();
+    const stmt = db.prepare(`
+      UPDATE webhook_deliveries
+      SET status = 'success',
+          response_code = ?,
+          last_error = NULL,
+          updated_at = ?,
+          delivered_at = ?
+      WHERE id = ?
+    `);
+    stmt.run(responseCode, now, now, deliveryId);
+  }
+
+  markDeliveryFailure(deliveryId: number, attemptCount: number, error: string, responseCode?: number): void {
+    const now = Date.now();
+    const stmt = db.prepare(`
+      UPDATE webhook_deliveries
+      SET status = 'failed',
+          attempt_count = ?,
+          response_code = ?,
+          last_error = ?,
+          updated_at = ?
+      WHERE id = ?
+    `);
+    stmt.run(attemptCount, responseCode ?? null, error.slice(0, 1000), now, deliveryId);
+  }
+
+  listDeliveriesForUser(userId: number, limit: number = 50): Array<WebhookDelivery & { webhook_name: string }> {
+    const stmt = db.prepare(`
+      SELECT d.*, w.name as webhook_name
+      FROM webhook_deliveries d
+      JOIN webhooks w ON d.webhook_id = w.id
+      WHERE w.user_id = ?
+      ORDER BY d.created_at DESC
+      LIMIT ?
+    `);
+    return stmt.all(userId, limit) as Array<WebhookDelivery & { webhook_name: string }>;
+  }
+}
+
+export const webhookRepository = new WebhookRepository();

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -217,3 +217,37 @@ CREATE TABLE IF NOT EXISTS relays (
 
 CREATE INDEX IF NOT EXISTS idx_relays_status ON relays(status);
 CREATE INDEX IF NOT EXISTS idx_relays_region ON relays(region);
+
+-- Outbound webhooks (user-managed event subscriptions)
+CREATE TABLE IF NOT EXISTS webhooks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  target_url TEXT NOT NULL,
+  secret TEXT NOT NULL,
+  event_filters TEXT NOT NULL, -- JSON array of event names
+  enabled INTEGER DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  webhook_id INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending', -- pending|success|failed
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  response_code INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  delivered_at INTEGER,
+  FOREIGN KEY (webhook_id) REFERENCES webhooks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhooks_user ON webhooks(user_id);
+CREATE INDEX IF NOT EXISTS idx_webhooks_enabled ON webhooks(enabled);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook ON webhook_deliveries(webhook_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status, updated_at);

--- a/backend/src/plugins/loader.ts
+++ b/backend/src/plugins/loader.ts
@@ -213,9 +213,9 @@ export class PluginLoader {
 
   // Hook methods for core to call
   async triggerOnMessage(channelId: string, message: any) {
-    for (const { plugin } of this.plugins.values()) {
+    for (const [pluginId, { plugin }] of this.plugins.entries()) {
       try {
-        await plugin.onMessage?.(channelId, message, this.createContext(plugin.name));
+        await plugin.onMessage?.(channelId, message, this.createContext(pluginId));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onMessage:`, error);
       }
@@ -223,9 +223,9 @@ export class PluginLoader {
   }
 
   async triggerOnChannelCreate(channel: any) {
-    for (const { plugin } of this.plugins.values()) {
+    for (const [pluginId, { plugin }] of this.plugins.entries()) {
       try {
-        await plugin.onChannelCreate?.(channel, this.createContext(plugin.name));
+        await plugin.onChannelCreate?.(channel, this.createContext(pluginId));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onChannelCreate:`, error);
       }
@@ -233,9 +233,9 @@ export class PluginLoader {
   }
 
   async triggerOnUserJoin(user: any) {
-    for (const { plugin } of this.plugins.values()) {
+    for (const [pluginId, { plugin }] of this.plugins.entries()) {
       try {
-        await plugin.onUserJoin?.(user, this.createContext(plugin.name));
+        await plugin.onUserJoin?.(user, this.createContext(pluginId));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onUserJoin:`, error);
       }
@@ -243,9 +243,9 @@ export class PluginLoader {
   }
 
   async triggerOnUserLeave(userId: string) {
-    for (const { plugin } of this.plugins.values()) {
+    for (const [pluginId, { plugin }] of this.plugins.entries()) {
       try {
-        await plugin.onUserLeave?.(userId, this.createContext(plugin.name));
+        await plugin.onUserLeave?.(userId, this.createContext(pluginId));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onUserLeave:`, error);
       }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,12 +18,14 @@ import { handleRegister, handleLogin, handleUpgrade, handleGetUserSettings, hand
 import { handleGetThemePreferences, handleSaveThemePreferences, handleResetThemePreferences } from "./api/themeRoutes.js";
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
 import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
+import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handleListWebhookDeliveries } from "./api/webhookRoutes.js";
 import { relayRepository } from "./db/repositories/relayRepository.js";
 import { corsCallback, getCORSHeaders, getAllowedOrigins, isOriginAllowed } from "./config/cors.js";
 import { channelRepository } from "./db/repositories/channelRepository.js";
 import { channelMemberRepository } from "./db/repositories/channelMemberRepository.js";
 import { messageRepository } from "./db/repositories/messageRepository.js";
 import { getUserRoles, assignRole, removeRole } from "./auth/roleMiddleware.js";
+import { dispatchWebhookEvent } from "./webhooks/deliveryService.js";
 
 // Helper: get role info for a user (roles, highest role, display color)
 function getUserRoleInfo(dbUserId?: number): { roles: string[]; highestRole: string; roleColor: string | null } {
@@ -1003,6 +1005,27 @@ server.on('request', async (req, res) => {
 
   if (url.pathname === "/api/media/gateway-heartbeat" && req.method === "POST") {
     await handleMediaGatewayHeartbeat(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/webhooks" && req.method === "POST") {
+    await handleCreateWebhook(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/webhooks" && req.method === "GET") {
+    await handleListWebhooks(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/webhooks/deliveries" && req.method === "GET") {
+    await handleListWebhookDeliveries(req, res);
+    return;
+  }
+
+  const webhookDeleteMatch = url.pathname.match(/^\/api\/webhooks\/(\d+)$/);
+  if (webhookDeleteMatch && req.method === "DELETE") {
+    await handleDeleteWebhook(req, res, parseInt(webhookDeleteMatch[1], 10));
     return;
   }
 
@@ -2420,6 +2443,20 @@ io.on("connection", (socket) => {
           usernameFont
         });
 
+        const joinedUser = users.get(socket.id);
+        if (joinedUser) {
+          pluginLoader.triggerOnUserJoin(joinedUser).catch((error) => {
+            console.error('[Plugins] Failed to trigger onUserJoin hook:', error);
+          });
+          dispatchWebhookEvent('user.joined', {
+            id: joinedUser.id,
+            username: joinedUser.username,
+            dbUserId: joinedUser.dbUserId || null
+          }).catch((error) => {
+            console.error('[Webhooks] Failed to dispatch user.joined:', error);
+          });
+        }
+
         if (ENABLE_LOGGING) console.log(`${registeredUsername} joined as registered user`);
         return; // Exit early - don't create temp session
       }
@@ -2471,6 +2508,11 @@ io.on("connection", (socket) => {
       });
 
       if (ENABLE_LOGGING) console.log(`${session.username} re-joined the chat with a new socket`);
+      const rejoinedUser = users.get(socket.id);
+      if (rejoinedUser) {
+        pluginLoader.triggerOnUserJoin(rejoinedUser).catch((error) => console.error('[Plugins] Failed to trigger onUserJoin hook:', error));
+        dispatchWebhookEvent('user.joined', { id: rejoinedUser.id, username: rejoinedUser.username, dbUserId: rejoinedUser.dbUserId || null }).catch((error) => console.error('[Webhooks] Failed to dispatch user.joined:', error));
+      }
     } else {
       // No session exists, create a new one (guest user)
       const color = `#${Math.floor(Math.random()*16777215).toString(16)}`;
@@ -2510,6 +2552,12 @@ io.on("connection", (socket) => {
         status: 'active',
         profilePicture: undefined
       });
+
+      const newUser = users.get(socket.id);
+      if (newUser) {
+        pluginLoader.triggerOnUserJoin(newUser).catch((error) => console.error('[Plugins] Failed to trigger onUserJoin hook:', error));
+        dispatchWebhookEvent('user.joined', { id: newUser.id, username: newUser.username, dbUserId: newUser.dbUserId || null }).catch((error) => console.error('[Webhooks] Failed to dispatch user.joined:', error));
+      }
 
       if (ENABLE_LOGGING) console.log(`${username} joined the chat as guest`);
     }
@@ -2606,6 +2654,11 @@ io.on("connection", (socket) => {
       roleColor: rejoinUser?.roleColor,
       usernameFont: rejoinUser?.usernameFont
     });
+
+    if (rejoinUser) {
+      pluginLoader.triggerOnUserJoin(rejoinUser).catch((error) => console.error('[Plugins] Failed to trigger onUserJoin hook:', error));
+      dispatchWebhookEvent('user.joined', { id: rejoinUser.id, username: rejoinUser.username, dbUserId: rejoinUser.dbUserId || null }).catch((error) => console.error('[Webhooks] Failed to dispatch user.joined:', error));
+    }
 
     if (ENABLE_LOGGING) console.log(`${session.username} rejoined the chat`);
   });
@@ -2893,6 +2946,20 @@ io.on("connection", (socket) => {
     } catch (dbError) {
       console.error('[MessageRepository] Failed to persist message:', dbError);
     }
+
+    pluginLoader.triggerOnMessage(data.channelId, message).catch((error) => {
+      console.error('[Plugins] Failed to trigger onMessage hook:', error);
+    });
+    dispatchWebhookEvent('message.created', {
+      channelId: data.channelId,
+      messageId: message.id,
+      userId: senderStableId,
+      username: user.username,
+      type: data.type,
+      text: data.text
+    }).catch((error) => {
+      console.error('[Webhooks] Failed to dispatch message.created:', error);
+    });
 
     // Clear typing indicator for this channel
     if (typingUsers.has(socket.id)) {
@@ -3388,6 +3455,18 @@ io.on("connection", (socket) => {
     pinnedMessages.set(channelId, new Set());
 
     io.emit("channel-created", channel);
+
+    pluginLoader.triggerOnChannelCreate(channel).catch((error) => {
+      console.error('[Plugins] Failed to trigger onChannelCreate hook:', error);
+    });
+    dispatchWebhookEvent('channel.created', {
+      channelId: channel.id,
+      name: channel.name,
+      type: channel.type || 'public'
+    }).catch((error) => {
+      console.error('[Webhooks] Failed to dispatch channel.created:', error);
+    });
+
     if (ENABLE_LOGGING) console.log(`Channel created: ${channelName}`);
   });
 
@@ -3824,6 +3903,17 @@ io.on("connection", (socket) => {
       }
     });
 
+    pluginLoader.triggerOnChannelCreate(groupPayload).catch((error) => {
+      console.error('[Plugins] Failed to trigger onChannelCreate hook:', error);
+    });
+    dispatchWebhookEvent('channel.created', {
+      channelId: groupPayload.id,
+      name: groupPayload.name,
+      type: groupPayload.type
+    }).catch((error) => {
+      console.error('[Webhooks] Failed to dispatch channel.created:', error);
+    });
+
     if (ENABLE_LOGGING) console.log(`Group created: ${data.name} (${groupId}) by ${user.username}`);
   });
 
@@ -4174,6 +4264,17 @@ io.on("connection", (socket) => {
       socket.broadcast.emit("user-left", {
         id: socket.id,
         username: user.username
+      });
+
+      pluginLoader.triggerOnUserLeave(socket.id).catch((error) => {
+        console.error('[Plugins] Failed to trigger onUserLeave hook:', error);
+      });
+      dispatchWebhookEvent('user.left', {
+        id: socket.id,
+        username: user.username,
+        dbUserId: user.dbUserId || null
+      }).catch((error) => {
+        console.error('[Webhooks] Failed to dispatch user.left:', error);
       });
 
       if (ENABLE_LOGGING) console.log(`${user.username} left the chat`);

--- a/backend/src/webhooks/deliveryService.ts
+++ b/backend/src/webhooks/deliveryService.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { webhookRepository } from '../db/repositories/webhookRepository.js';
+import { webhookRepository, type Webhook } from '../db/repositories/webhookRepository.js';
 
 export const WEBHOOK_EVENTS = [
   'message.created',
@@ -12,9 +12,20 @@ export type WebhookEventType = (typeof WEBHOOK_EVENTS)[number];
 
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAYS_MS = [500, 1500, 4000];
+const REQUEST_TIMEOUT_MS = 5000;
 
 function signPayload(secret: string, body: string): string {
   return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function shouldDispatchWebhook(webhook: Webhook, eventType: WebhookEventType): boolean {
+  try {
+    const filters = JSON.parse(webhook.event_filters);
+    if (!Array.isArray(filters)) return false;
+    return filters.includes('*') || filters.includes(eventType);
+  } catch {
+    return false;
+  }
 }
 
 async function deliverWithRetry(webhook: { id: number; target_url: string; secret: string }, eventType: WebhookEventType, body: string): Promise<void> {
@@ -29,6 +40,11 @@ async function deliverWithRetry(webhook: { id: number; target_url: string; secre
 
   while (attempt < MAX_ATTEMPTS) {
     attempt += 1;
+    webhookRepository.markDeliveryAttempt(deliveryId, attempt);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
     try {
       const response = await fetch(webhook.target_url, {
         method: 'POST',
@@ -38,11 +54,14 @@ async function deliverWithRetry(webhook: { id: number; target_url: string; secre
           'x-wabi-delivery-id': String(deliveryId),
           'x-wabi-signature': signPayload(webhook.secret, body)
         },
-        body
+        body,
+        signal: controller.signal
       });
 
+      clearTimeout(timeout);
+
       if (response.ok) {
-        webhookRepository.markDeliverySuccess(deliveryId, response.status);
+        webhookRepository.markDeliverySuccess(deliveryId, response.status, attempt);
         return;
       }
 
@@ -52,6 +71,7 @@ async function deliverWithRetry(webhook: { id: number; target_url: string; secre
         return;
       }
     } catch (error) {
+      clearTimeout(timeout);
       lastError = error instanceof Error ? error.message : 'Network error';
       if (attempt >= MAX_ATTEMPTS) {
         webhookRepository.markDeliveryFailure(deliveryId, attempt, lastError);
@@ -67,7 +87,7 @@ async function deliverWithRetry(webhook: { id: number; target_url: string; secre
 }
 
 export async function dispatchWebhookEvent(eventType: WebhookEventType, payload: Record<string, any>): Promise<void> {
-  const webhooks = webhookRepository.listEnabledByEvent(eventType);
+  const webhooks = webhookRepository.listEnabled().filter((webhook) => shouldDispatchWebhook(webhook, eventType));
   if (webhooks.length === 0) return;
 
   const body = JSON.stringify({

--- a/backend/src/webhooks/deliveryService.ts
+++ b/backend/src/webhooks/deliveryService.ts
@@ -1,0 +1,82 @@
+import crypto from 'crypto';
+import { webhookRepository } from '../db/repositories/webhookRepository.js';
+
+export const WEBHOOK_EVENTS = [
+  'message.created',
+  'channel.created',
+  'user.joined',
+  'user.left'
+] as const;
+
+export type WebhookEventType = (typeof WEBHOOK_EVENTS)[number];
+
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [500, 1500, 4000];
+
+function signPayload(secret: string, body: string): string {
+  return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+async function deliverWithRetry(webhook: { id: number; target_url: string; secret: string }, eventType: WebhookEventType, body: string): Promise<void> {
+  const deliveryId = webhookRepository.createDelivery({
+    webhook_id: webhook.id,
+    event_type: eventType,
+    payload_json: body
+  });
+
+  let attempt = 0;
+  let lastError = 'Unknown delivery failure';
+
+  while (attempt < MAX_ATTEMPTS) {
+    attempt += 1;
+    try {
+      const response = await fetch(webhook.target_url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-wabi-event': eventType,
+          'x-wabi-delivery-id': String(deliveryId),
+          'x-wabi-signature': signPayload(webhook.secret, body)
+        },
+        body
+      });
+
+      if (response.ok) {
+        webhookRepository.markDeliverySuccess(deliveryId, response.status);
+        return;
+      }
+
+      lastError = `HTTP ${response.status}`;
+      if (attempt >= MAX_ATTEMPTS) {
+        webhookRepository.markDeliveryFailure(deliveryId, attempt, lastError, response.status);
+        return;
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : 'Network error';
+      if (attempt >= MAX_ATTEMPTS) {
+        webhookRepository.markDeliveryFailure(deliveryId, attempt, lastError);
+        return;
+      }
+    }
+
+    const retryDelay = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+    await new Promise((resolve) => setTimeout(resolve, retryDelay));
+  }
+
+  webhookRepository.markDeliveryFailure(deliveryId, attempt, lastError);
+}
+
+export async function dispatchWebhookEvent(eventType: WebhookEventType, payload: Record<string, any>): Promise<void> {
+  const webhooks = webhookRepository.listEnabledByEvent(eventType);
+  if (webhooks.length === 0) return;
+
+  const body = JSON.stringify({
+    event: eventType,
+    timestamp: Date.now(),
+    data: payload
+  });
+
+  await Promise.allSettled(
+    webhooks.map((webhook) => deliverWithRetry(webhook, eventType, body))
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide durable outbound webhook subscriptions and delivery auditing so users can subscribe to core events from external services.  
- Integrate outbound webhooks with core realtime events (`message.created`, `channel.created`, `user.joined`, `user.left`) so external systems can react to chat activity.  
- Ensure plugin lifecycle hooks run reliably from core events and fix plugin context identity to avoid incorrect storage/permissions for plugin data.

### Description
- Add persistent schema for webhooks and webhook deliveries (`webhooks`, `webhook_deliveries`) and relevant indexes in `backend/src/db/schema.sql`.  
- Implement `WebhookRepository` with CRUD and delivery tracking in `backend/src/db/repositories/webhookRepository.ts`.  
- Add a webhook delivery service (`backend/src/webhooks/deliveryService.ts`) that signs payloads (`x-wabi-signature`), records deliveries, and retries with backoff.  
- Expose authenticated management endpoints in `backend/src/api/webhookRoutes.ts` and wire them into the server router: `POST /api/webhooks`, `GET /api/webhooks`, `DELETE /api/webhooks/:id`, and `GET /api/webhooks/deliveries`.  
- Wire core event emissions to both plugin hooks and outbound webhooks in `backend/src/server.ts` for user join/rejoin, user leave, message create, and channel/group create, using guarded async calls so failures don’t impact chat flow.  
- Fix plugin loader context bug by using the stable `pluginId` when creating plugin contexts in `backend/src/plugins/loader.ts`.

### Testing
- Built the backend bundle with `cd backend && npm run build` and the build completed successfully (esbuild produced `dist/server.js`).  
- No automated test suite was present for webhooks; the change was validated by performing a full build and smoke-checking the modified server routing and plugin hook invocations.  

ALL TASKS DONE

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699037352e50832aae7914a621f47c1e)