### PR TITLE
Hide public/private visibility option when re-signing Kanban tasks

### DIFF
--- a/frontend/src/lib/components/business/KanbanBoard.svelte
+++ b/frontend/src/lib/components/business/KanbanBoard.svelte
@@ -34,6 +34,7 @@
 	// Modal state
 	let showAddModal = false;
 	let editingTodo: Todo | null = null;
+	$: isSigningAgain = !!editingTodo?.signedBy;
 	let targetColumn: TodoStatus = 'todo';
 
 	// Form state
@@ -729,24 +730,26 @@
 				<div class="form-group checkbox-group">
 					<label class="checkbox-label">
 						<input type="checkbox" bind:checked={willSign} />
-						<span>Sign this task with my username</span>
+						<span>{isSigningAgain ? 'Sign again with my username' : 'Sign this task with my username'}</span>
 					</label>
 				</div>
 
-				<!-- Visibility toggle -->
-				<div class="form-group">
-					<label>Visibility</label>
-					<div class="radio-group">
-						<label class="radio-label">
-							<input type="radio" bind:group={formVisibility} value="public" />
-							<span>Public (visible to collaborators)</span>
-						</label>
-						<label class="radio-label">
-							<input type="radio" bind:group={formVisibility} value="private" />
-							<span>Private (only me)</span>
-						</label>
+				{#if !isSigningAgain}
+					<!-- Visibility toggle -->
+					<div class="form-group">
+						<label>Visibility</label>
+						<div class="radio-group">
+							<label class="radio-label">
+								<input type="radio" bind:group={formVisibility} value="public" />
+								<span>Public (visible to collaborators)</span>
+							</label>
+							<label class="radio-label">
+								<input type="radio" bind:group={formVisibility} value="private" />
+								<span>Private (only me)</span>
+							</label>
+						</div>
 					</div>
-				</div>
+				{/if}
 
 				<div class="form-actions">
 					{#if editingTodo}


### PR DESCRIPTION
### Motivation
- Fix a small UI/UX glitch where the public/private visibility radio is shown when a user is performing a "sign again" on an already-signed task; the visibility choice should not be presented during the re-sign flow.

### Description
- Detect the sign-again case by adding a reactive flag `isSigningAgain = !!editingTodo?.signedBy` in `frontend/src/lib/components/business/KanbanBoard.svelte` and update the signature label to conditionally show "Sign again with my username".
- Wrap the visibility radio group in a `{#if !isSigningAgain}` so the public/private choices are hidden only for the sign-again flow; no other save/sync logic was changed.

### Testing
- Started a local preview with `npm run dev` and confirmed the app served (Vite ready), ran `npm run check` (which runs `svelte-check`) and it reported many pre-existing diagnostics unrelated to this small change, and attempted an automated Playwright screenshot of the `/business` Kanban modal which failed due to instability/timeouts in the headless browser in this environment, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e79bc1bc832a8b0def9d7da538f0)