### PR TITLE
Add settings toggle for legacy call fallback behavior

### DIFF
--- a/frontend/src/lib/calling.ts
+++ b/frontend/src/lib/calling.ts
@@ -1,7 +1,7 @@
 import { writable, get } from 'svelte/store';
 import type { Socket } from 'socket.io-client';
 import { buildRTCConfig } from './turnConfig';
-import { getMediaRuntimeConfig, getScreenShareQualityProfile } from './mediaRuntime';
+import { getMediaRuntimeConfig, getScreenShareQualityProfile, isLegacyCallFallbackEnabled } from './mediaRuntime';
 
 const CAMERA_CONSTRAINTS: MediaTrackConstraints = {
 	width: { ideal: 1280, max: 1920 },
@@ -456,21 +456,40 @@ function updateRemoteTrackState(targetId: string, track: MediaStreamTrack, type:
 // Call Functions
 // ============================================================================
 
-export async function startCall(socket: Socket, targetUserId: string, isVideoCall: boolean = false) {
+
+async function getCallStreamWithFallback(isVideoCall: boolean): Promise<{ stream: MediaStream; usedVideo: boolean }> {
 	try {
 		const stream = await navigator.mediaDevices.getUserMedia({
 			video: isVideoCall ? CAMERA_CONSTRAINTS : false,
 			audio: true
 		});
+		return { stream, usedVideo: isVideoCall };
+	} catch (error) {
+		if (!isVideoCall || !isLegacyCallFallbackEnabled()) {
+			throw error;
+		}
+
+		console.warn('[WebRTC] Video call setup failed, using audio-only fallback mode:', error);
+		const fallbackStream = await navigator.mediaDevices.getUserMedia({
+			video: false,
+			audio: true
+		});
+		return { stream: fallbackStream, usedVideo: false };
+	}
+}
+
+export async function startCall(socket: Socket, targetUserId: string, isVideoCall: boolean = false) {
+	try {
+		const { stream, usedVideo } = await getCallStreamWithFallback(isVideoCall);
 		localStream.set(stream);
 
 		isInCall.set(true);
 		isMuted.set(false);
-		isVideoOff.set(!isVideoCall);
+		isVideoOff.set(!usedVideo);
 
 		socket.emit('call-initiate', {
 			targetUserId,
-			isVideoCall
+			isVideoCall: usedVideo
 		});
 
 		return stream;
@@ -485,19 +504,16 @@ export async function startCall(socket: Socket, targetUserId: string, isVideoCal
 
 export async function answerCall(socket: Socket, callerId: string, isVideoCall: boolean = false) {
 	try {
-		const stream = await navigator.mediaDevices.getUserMedia({
-			video: isVideoCall ? CAMERA_CONSTRAINTS : false,
-			audio: true
-		});
+		const { stream, usedVideo } = await getCallStreamWithFallback(isVideoCall);
 		localStream.set(stream);
 
 		isInCall.set(true);
 		isMuted.set(false);
-		isVideoOff.set(!isVideoCall);
+		isVideoOff.set(!usedVideo);
 
 		socket.emit('call-answer', {
 			callerId,
-			isVideoCall
+			isVideoCall: usedVideo
 		});
 
 		incomingCall.set(null);

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -21,10 +21,12 @@
 		getStoredMediaQualityMode,
 		getStoredScreenShareQualityPreset,
 		isSrtGatewayEnabled,
+		isLegacyCallFallbackEnabled,
 		isTauriRuntime,
 		setMediaQualityMode,
 		setScreenShareQualityPreset,
 		setSrtGatewayEnabled,
+		setLegacyCallFallbackEnabled,
 		syncMediaRuntimeFromServer,
 		type MediaQualityMode,
 		type ScreenShareQualityPreset
@@ -43,6 +45,7 @@
 	let mediaQualityMode: MediaQualityMode = 'web-baseline';
 	let srtGatewayEnabled = false;
 	let screenShareQualityPreset: ScreenShareQualityPreset = 'auto';
+	let legacyCallFallbackEnabled = true;
 	let localAppRuntime = false;
 
 	// Theme saving state
@@ -87,6 +90,7 @@
 			mediaQualityMode = getStoredMediaQualityMode();
 			srtGatewayEnabled = isSrtGatewayEnabled();
 			screenShareQualityPreset = getStoredScreenShareQualityPreset();
+			legacyCallFallbackEnabled = isLegacyCallFallbackEnabled();
 		})();
 	});
 
@@ -124,6 +128,11 @@
 	function updateScreenShareQualityPreset(preset: ScreenShareQualityPreset) {
 		screenShareQualityPreset = preset;
 		setScreenShareQualityPreset(preset);
+	}
+
+	function toggleLegacyCallFallback() {
+		legacyCallFallbackEnabled = !legacyCallFallbackEnabled;
+		setLegacyCallFallbackEnabled(legacyCallFallbackEnabled);
 	}
 
 	// Handle theme change
@@ -680,6 +689,17 @@
 						</div>
 						<button class="toggle-btn" class:active={srtGatewayEnabled} on:click={toggleSrtGateway} disabled={!localAppRuntime}>
 							{srtGatewayEnabled ? 'ON' : 'OFF'}
+						</button>
+					</div>
+
+
+					<div class="setting-item">
+						<div class="setting-info">
+							<span class="setting-label">Legacy Call Fallback</span>
+							<span class="setting-description">If a video call fails to start, retry automatically as audio-only.</span>
+						</div>
+						<button class="toggle-btn" class:active={legacyCallFallbackEnabled} on:click={toggleLegacyCallFallback}>
+							{legacyCallFallbackEnabled ? 'ON' : 'OFF'}
 						</button>
 					</div>
 

--- a/frontend/src/lib/mediaRuntime.ts
+++ b/frontend/src/lib/mediaRuntime.ts
@@ -46,7 +46,8 @@ export interface MediaRuntimeConfig {
 const STORAGE_KEYS = {
 	qualityMode: 'wabi_media_quality_mode',
 	srtGateway: 'wabi_enable_srt_gateway',
-	screenShareQuality: 'wabi_screen_share_quality_preset'
+	screenShareQuality: 'wabi_screen_share_quality_preset',
+	legacyCallFallback: 'wabi_enable_legacy_call_fallback'
 };
 
 const SCREEN_SHARE_QUALITY_PROFILES: Record<ScreenShareQualityPreset, ScreenShareQualityProfile> = {
@@ -187,6 +188,18 @@ export function getStoredMediaQualityMode(): MediaQualityMode {
 export function isSrtGatewayEnabled(): boolean {
 	if (!browser) return false;
 	return localStorage.getItem(STORAGE_KEYS.srtGateway) === 'true';
+}
+
+export function setLegacyCallFallbackEnabled(enabled: boolean): void {
+	if (!browser) return;
+	localStorage.setItem(STORAGE_KEYS.legacyCallFallback, String(enabled));
+}
+
+export function isLegacyCallFallbackEnabled(): boolean {
+	if (!browser) return true;
+	const stored = localStorage.getItem(STORAGE_KEYS.legacyCallFallback);
+	if (stored === null) return true;
+	return stored === 'true';
 }
 
 export async function syncMediaRuntimeFromServer(): Promise<ServerMediaRuntimeResponse | null> {


### PR DESCRIPTION
### Motivation
- Add a user-configurable fallback for call setup so the app can automatically retry a failed video call as audio-only, surfaced from the Settings UI as requested.

### Description
- `frontend/src/lib/mediaRuntime.ts`: added storage key `wabi_enable_legacy_call_fallback` and implemented `setLegacyCallFallbackEnabled()` and `isLegacyCallFallbackEnabled()` with a safe default of `true` when unset.
- `frontend/src/lib/components/Settings.svelte`: imported the new getters/setters, initialized `legacyCallFallbackEnabled` on mount, added `toggleLegacyCallFallback()` handler, and added a toggle UI under Audio & Video labeled `Legacy Call Fallback`.
- `frontend/src/lib/calling.ts`: imported `isLegacyCallFallbackEnabled`, added helper `getCallStreamWithFallback(isVideoCall)` which falls back to audio-only when video acquisition fails and the setting is enabled, and updated `startCall()` and `answerCall()` to use the helper and emit the adjusted `isVideoCall`/video state.

### Testing
- Ran `cd frontend && npm run check` (invoked `svelte-check`) and observed it fail due to pre-existing unrelated TypeScript/Svelte issues in the repository, not caused by these changes.
- Started the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and verified the Settings UI manually; a Playwright-driven screenshot artifact was captured at `artifacts/settings-fallback.png` to show the new toggle.
- Verified the app runs (dev server up) for manual verification; no additional automated unit tests were added for this UI/behavior change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e666dfa4832ab616ced9b588a9fc)