### PR TITLE
Add server mute/deafen moderation (server-side voice controls)

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -105,6 +105,8 @@ const users = new Map<string, {
     weight?: string;
     style?: string;
   };
+  serverMuted?: boolean;
+  serverDeafened?: boolean;
 }>();
 
 // Reverse mapping: stable dbUserId -> current socket.id (for registered users only)
@@ -166,6 +168,8 @@ const screenSharers = new Map<string, {
 
 // Track active call peers: socketId -> Set of partner socketIds
 const activeCallPeers = new Map<string, Set<string>>();
+const serverMutedUsers = new Set<number>();
+const serverDeafenedUsers = new Set<number>();
 
 function addCallPeer(socketId: string, peerId: string) {
   if (!activeCallPeers.has(socketId)) activeCallPeers.set(socketId, new Set());
@@ -182,6 +186,33 @@ function removeAllCallPeers(socketId: string): Set<string> {
   }
   activeCallPeers.delete(socketId);
   return peers;
+}
+
+function canModerateVoice(userDbId?: number): boolean {
+  if (!userDbId) return false;
+  const roleInfo = getUserRoleInfo(userDbId);
+  return ['owner', 'admin', 'mod'].includes(roleInfo.highestRole);
+}
+
+function applyVoiceModerationState(socketId: string): void {
+  const user = users.get(socketId);
+  if (!user?.dbUserId) return;
+
+  io.to(socketId).emit('server-voice-state-updated', {
+    userId: socketId,
+    dbUserId: user.dbUserId,
+    serverMuted: serverMutedUsers.has(user.dbUserId),
+    serverDeafened: serverDeafenedUsers.has(user.dbUserId)
+  });
+}
+
+function serializeUserForClient(user: any): any {
+  const dbUserId = user?.dbUserId;
+  return {
+    ...user,
+    serverMuted: dbUserId ? serverMutedUsers.has(dbUserId) : false,
+    serverDeafened: dbUserId ? serverDeafenedUsers.has(dbUserId) : false
+  };
 }
 
 // Excalidraw state
@@ -2403,7 +2434,9 @@ io.on("connection", (socket) => {
           roles: roleInfo.roles,
           highestRole: roleInfo.highestRole,
           roleColor: roleInfo.roleColor,
-          usernameFont
+          usernameFont,
+          serverMuted: (socket as any).dbUserId ? serverMutedUsers.has((socket as any).dbUserId) : false,
+          serverDeafened: (socket as any).dbUserId ? serverDeafenedUsers.has((socket as any).dbUserId) : false
         });
 
         // Update reverse mapping for registered users
@@ -2419,7 +2452,7 @@ io.on("connection", (socket) => {
         const emojisData = getAllEmojis();
         socket.emit("init", {
           channels: enrichedChannels,
-          users: Array.from(users.values()),
+          users: Array.from(users.values()).map(serializeUserForClient),
           excalidrawState,
           emotes: Array.from(emotes.values()),
           emojis: emojisData,
@@ -2428,6 +2461,7 @@ io.on("connection", (socket) => {
 
         // Deliver offline messages for registered user
         await deliverOfflineMessages(socket, (socket as any).dbUserId);
+        applyVoiceModerationState(socket.id);
 
         socket.broadcast.emit("user-joined", {
           id: socket.id,
@@ -2440,7 +2474,9 @@ io.on("connection", (socket) => {
           roles: roleInfo.roles,
           highestRole: roleInfo.highestRole,
           roleColor: roleInfo.roleColor,
-          usernameFont
+          usernameFont,
+          serverMuted: (socket as any).dbUserId ? serverMutedUsers.has((socket as any).dbUserId) : false,
+          serverDeafened: (socket as any).dbUserId ? serverDeafenedUsers.has((socket as any).dbUserId) : false
         });
 
         const joinedUser = users.get(socket.id);
@@ -2483,7 +2519,9 @@ io.on("connection", (socket) => {
         username: session.username,
         color: session.color,
         status: 'active',
-        profilePicture: session.profilePicture
+        profilePicture: session.profilePicture,
+      serverMuted: false,
+      serverDeafened: false
       });
 
       // Guest users use socket.id as their stable ID (ephemeral, expected)
@@ -2492,7 +2530,7 @@ io.on("connection", (socket) => {
       const emojisData = getAllEmojis();
       socket.emit("init", {
         channels: guestChannels,
-        users: Array.from(users.values()),
+        users: Array.from(users.values()).map(serializeUserForClient),
         excalidrawState,
         emotes: Array.from(emotes.values()),
         emojis: emojisData,
@@ -2504,7 +2542,9 @@ io.on("connection", (socket) => {
         username: session.username,
         color: session.color,
         status: 'active',
-        profilePicture: session.profilePicture
+        profilePicture: session.profilePicture,
+      serverMuted: false,
+      serverDeafened: false
       });
 
       if (ENABLE_LOGGING) console.log(`${session.username} re-joined the chat with a new socket`);
@@ -2529,7 +2569,9 @@ io.on("connection", (socket) => {
         username,
         color,
         status: 'active',
-        profilePicture: undefined
+        profilePicture: undefined,
+      serverMuted: false,
+      serverDeafened: false
       });
 
       // Guest users use socket.id as their stable ID (ephemeral, expected)
@@ -2538,7 +2580,7 @@ io.on("connection", (socket) => {
       const emojisData2 = getAllEmojis();
       socket.emit("init", {
         channels: newGuestChannels,
-        users: Array.from(users.values()),
+        users: Array.from(users.values()).map(serializeUserForClient),
         excalidrawState,
         emotes: Array.from(emotes.values()),
         emojis: emojisData2,
@@ -2550,7 +2592,9 @@ io.on("connection", (socket) => {
         username,
         color,
         status: 'active',
-        profilePicture: undefined
+        profilePicture: undefined,
+      serverMuted: false,
+      serverDeafened: false
       });
 
       const newUser = users.get(socket.id);
@@ -2627,7 +2671,7 @@ io.on("connection", (socket) => {
     const emojisData = getAllEmojis();
     socket.emit("init", {
       channels: enrichedRejoinChannels,
-      users: Array.from(users.values()),
+      users: Array.from(users.values()).map(serializeUserForClient),
       excalidrawState,
       emotes: Array.from(emotes.values()),
       emojis: emojisData,
@@ -2637,6 +2681,7 @@ io.on("connection", (socket) => {
     // Deliver offline messages for registered user on rejoin
     if (rejoinDbUserId) {
       deliverOfflineMessages(socket, rejoinDbUserId);
+      applyVoiceModerationState(socket.id);
     }
 
     // Broadcast user rejoin
@@ -2652,7 +2697,9 @@ io.on("connection", (socket) => {
       roles: rejoinUser?.roles,
       highestRole: rejoinUser?.highestRole,
       roleColor: rejoinUser?.roleColor,
-      usernameFont: rejoinUser?.usernameFont
+      usernameFont: rejoinUser?.usernameFont,
+      serverMuted: rejoinDbUserId ? serverMutedUsers.has(rejoinDbUserId) : false,
+      serverDeafened: rejoinDbUserId ? serverDeafenedUsers.has(rejoinDbUserId) : false
     });
 
     if (rejoinUser) {
@@ -3791,6 +3838,85 @@ io.on("connection", (socket) => {
       socket.emit("channel-error", "Failed to remove role");
     }
   });
+
+  socket.on("server-set-mute", (data: { targetUserId: number; muted: boolean }) => {
+    const user = users.get(socket.id);
+    if (!canModerateVoice(user?.dbUserId)) {
+      socket.emit("channel-error", "Insufficient permissions to server mute users");
+      return;
+    }
+
+    if (data.muted) {
+      serverMutedUsers.add(data.targetUserId);
+    } else {
+      serverMutedUsers.delete(data.targetUserId);
+    }
+
+    let targetSocketId: string | undefined;
+    for (const [sid, u] of users.entries()) {
+      if (u.dbUserId === data.targetUserId) {
+        u.serverMuted = data.muted;
+        users.set(sid, u);
+        targetSocketId = sid;
+        break;
+      }
+    }
+
+    io.emit("user-voice-moderation-updated", {
+      dbUserId: data.targetUserId,
+      serverMuted: data.muted,
+      serverDeafened: serverDeafenedUsers.has(data.targetUserId)
+    });
+
+    if (targetSocketId) {
+      io.to(targetSocketId).emit("server-force-call-controls", {
+        serverMuted: data.muted,
+        serverDeafened: serverDeafenedUsers.has(data.targetUserId)
+      });
+      applyVoiceModerationState(targetSocketId);
+    }
+  });
+
+  socket.on("server-set-deafen", (data: { targetUserId: number; deafened: boolean }) => {
+    const user = users.get(socket.id);
+    if (!canModerateVoice(user?.dbUserId)) {
+      socket.emit("channel-error", "Insufficient permissions to server deafen users");
+      return;
+    }
+
+    if (data.deafened) {
+      serverDeafenedUsers.add(data.targetUserId);
+      serverMutedUsers.add(data.targetUserId);
+    } else {
+      serverDeafenedUsers.delete(data.targetUserId);
+    }
+
+    let targetSocketId: string | undefined;
+    for (const [sid, u] of users.entries()) {
+      if (u.dbUserId === data.targetUserId) {
+        u.serverDeafened = data.deafened;
+        if (data.deafened) u.serverMuted = true;
+        users.set(sid, u);
+        targetSocketId = sid;
+        break;
+      }
+    }
+
+    io.emit("user-voice-moderation-updated", {
+      dbUserId: data.targetUserId,
+      serverMuted: serverMutedUsers.has(data.targetUserId),
+      serverDeafened: data.deafened
+    });
+
+    if (targetSocketId) {
+      io.to(targetSocketId).emit("server-force-call-controls", {
+        serverMuted: serverMutedUsers.has(data.targetUserId),
+        serverDeafened: data.deafened
+      });
+      applyVoiceModerationState(targetSocketId);
+    }
+  });
+
 
   // Group chat creation
   socket.on("create-group", (data: { name: string; memberIds: string[] }) => {

--- a/frontend/src/lib/calling.ts
+++ b/frontend/src/lib/calling.ts
@@ -66,6 +66,8 @@ export const isInCall = writable(false);
 export const isSharing = writable(false);
 export const isMuted = writable(false);
 export const isDeafened = writable(false);
+export const serverMuteLocked = writable(false);
+export const serverDeafenLocked = writable(false);
 export const isVideoOff = writable(false);
 export const localStream = writable<MediaStream | null>(null);
 export const localScreenStream = writable<MediaStream | null>(null);
@@ -530,6 +532,8 @@ export function endCall(socket: Socket) {
 	isMuted.set(false);
 	isDeafened.set(false);
 	isVideoOff.set(false);
+	serverMuteLocked.set(false);
+	serverDeafenLocked.set(false);
 
 	// Notify server with participant list for targeted cleanup
 	socket.emit('call-end', {
@@ -555,6 +559,7 @@ export function endCall(socket: Socket) {
 // ============================================================================
 
 export function toggleMute() {
+	if (get(serverMuteLocked) || get(serverDeafenLocked)) return;
 	const stream = get(localStream);
 	if (stream) {
 		const audioTrack = stream.getAudioTracks()[0];
@@ -566,6 +571,7 @@ export function toggleMute() {
 }
 
 export function toggleDeafen() {
+	if (get(serverDeafenLocked)) return;
 	const currentlyDeafened = get(isDeafened);
 	isDeafened.set(!currentlyDeafened);
 
@@ -631,6 +637,29 @@ export async function toggleVideo(socket?: Socket) {
 	} catch (error) {
 		console.error('[WebRTC] Could not enable camera track:', error);
 		handleMediaError(error as DOMException, 'starting');
+	}
+}
+
+
+export function setServerVoiceState(state: { serverMuted: boolean; serverDeafened: boolean }) {
+	serverMuteLocked.set(state.serverMuted);
+	serverDeafenLocked.set(state.serverDeafened);
+
+	if (state.serverDeafened) {
+		isDeafened.set(true);
+	}
+
+	if (state.serverMuted || state.serverDeafened) {
+		const stream = get(localStream);
+		if (stream) {
+			const audioTrack = stream.getAudioTracks()[0];
+			if (audioTrack) {
+				audioTrack.enabled = false;
+			}
+		}
+		isMuted.set(true);
+	} else if (!state.serverDeafened) {
+		isDeafened.set(false);
 	}
 }
 
@@ -901,6 +930,8 @@ export function cleanupAllConnections() {
 	isMuted.set(false);
 	isDeafened.set(false);
 	isVideoOff.set(false);
+	serverMuteLocked.set(false);
+	serverDeafenLocked.set(false);
 	connectionState.set('idle');
 }
 

--- a/frontend/src/lib/components/CallView.svelte
+++ b/frontend/src/lib/components/CallView.svelte
@@ -7,6 +7,8 @@
 		isMuted,
 		isDeafened,
 		isVideoOff,
+		serverMuteLocked,
+		serverDeafenLocked,
 		localStream,
 		localScreenStream,
 		connectionState,
@@ -304,7 +306,8 @@
 						class="control-btn"
 						class:active={$isMuted}
 						on:click={handleToggleMute}
-						title={$isMuted ? 'Unmute' : 'Mute'}
+						disabled={$serverMuteLocked || $serverDeafenLocked}
+						title={$serverMuteLocked || $serverDeafenLocked ? 'Server muted' : ($isMuted ? 'Unmute' : 'Mute')}
 					>
 						{#if $isMuted}
 							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -328,7 +331,8 @@
 						class="control-btn"
 						class:active={$isDeafened}
 						on:click={handleToggleDeafen}
-						title={$isDeafened ? 'Undeafen' : 'Deafen'}
+						disabled={$serverDeafenLocked}
+						title={$serverDeafenLocked ? 'Server deafened' : ($isDeafened ? 'Undeafen' : 'Deafen')}
 					>
 						{#if $isDeafened}
 							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/frontend/src/lib/components/UserListTab.svelte
+++ b/frontend/src/lib/components/UserListTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { users, currentUser, createDM, socket } from '$lib/socket';
+	import { users, currentUser, createDM, socket, setServerMute, setServerDeafen } from '$lib/socket';
 	import { layoutStore } from '$lib/layoutStore';
 	import { startCall } from '$lib/calling';
 	import type { User } from '$lib/socket';
@@ -37,6 +37,8 @@
 	$: sortedRoles = Object.keys(groupedUsers).sort(
 		(a, b) => (rolePriority[b] || 0) - (rolePriority[a] || 0)
 	);
+
+	$: canModerateVoice = ['owner', 'admin', 'mod'].includes($currentUser?.highestRole || '');
 
 	function handleUserClick(user: User) {
 		createDM(user.id);
@@ -76,6 +78,19 @@
 
 	function getDisplayColor(user: User): string {
 		return user.roleColor || user.color;
+	}
+
+
+	function handleServerMuteToggle() {
+		if (!contextMenuUser?.dbUserId) return;
+		setServerMute(contextMenuUser.dbUserId, !contextMenuUser.serverMuted);
+		closeContextMenu();
+	}
+
+	function handleServerDeafenToggle() {
+		if (!contextMenuUser?.dbUserId) return;
+		setServerDeafen(contextMenuUser.dbUserId, !contextMenuUser.serverDeafened);
+		closeContextMenu();
 	}
 
 	function getRoleBadge(user: User): string | null {
@@ -146,6 +161,15 @@
 			<button class="context-menu-item" on:click={handleContextVideoCall}>
 				Video Call
 			</button>
+
+			{#if canModerateVoice && contextMenuUser.dbUserId && contextMenuUser.id !== $currentUser?.id}
+				<button class="context-menu-item" on:click={handleServerMuteToggle}>
+					{contextMenuUser.serverMuted ? 'Remove Server Mute' : 'Server Mute'}
+				</button>
+				<button class="context-menu-item" on:click={handleServerDeafenToggle}>
+					{contextMenuUser.serverDeafened ? 'Remove Server Deafen' : 'Server Deafen'}
+				</button>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/frontend/src/lib/socket-manager.ts
+++ b/frontend/src/lib/socket-manager.ts
@@ -853,6 +853,34 @@ class SocketManager {
 			);
 		});
 
+		sock.on('user-voice-moderation-updated', (data: { dbUserId: number; serverMuted: boolean; serverDeafened: boolean }) => {
+			users.update(u => u.map(existing =>
+				existing.dbUserId === data.dbUserId
+					? { ...existing, serverMuted: data.serverMuted, serverDeafened: data.serverDeafened }
+					: existing
+			));
+
+			currentUser.update(cu => {
+				if (!cu || cu.dbUserId !== data.dbUserId) return cu;
+				calling.setServerVoiceState({ serverMuted: data.serverMuted, serverDeafened: data.serverDeafened });
+				return { ...cu, serverMuted: data.serverMuted, serverDeafened: data.serverDeafened };
+			});
+		});
+
+		sock.on('server-voice-state-updated', (data: { userId: string; dbUserId: number; serverMuted: boolean; serverDeafened: boolean }) => {
+			calling.setServerVoiceState({ serverMuted: data.serverMuted, serverDeafened: data.serverDeafened });
+			users.update(u => u.map(existing =>
+				existing.id === data.userId || existing.dbUserId === data.dbUserId
+					? { ...existing, serverMuted: data.serverMuted, serverDeafened: data.serverDeafened }
+					: existing
+			));
+			currentUser.update(cu => cu ? { ...cu, serverMuted: data.serverMuted, serverDeafened: data.serverDeafened } : cu);
+		});
+
+		sock.on('server-force-call-controls', (data: { serverMuted: boolean; serverDeafened: boolean }) => {
+			calling.setServerVoiceState(data);
+		});
+
 		sock.on('group-created', (group: Channel) => {
 			channels.update(chs => {
 				if (chs.some(ch => ch.id === group.id)) return chs;
@@ -1486,6 +1514,14 @@ export function assignRole(targetUserId: number, roleName: string): void {
 
 export function removeUserRole(targetUserId: number, roleName: string): void {
 	socketManager.emit('remove-role', { targetUserId, roleName });
+}
+
+export function setServerMute(targetUserId: number, muted: boolean): void {
+	socketManager.emit('server-set-mute', { targetUserId, muted });
+}
+
+export function setServerDeafen(targetUserId: number, deafened: boolean): void {
+	socketManager.emit('server-set-deafen', { targetUserId, deafened });
 }
 
 export function createGroup(name: string, memberIds: string[]): void {

--- a/frontend/src/lib/socket-types.ts
+++ b/frontend/src/lib/socket-types.ts
@@ -55,6 +55,8 @@ export interface User {
     weight?: string;
     style?: string;
   };
+  serverMuted?: boolean;
+  serverDeafened?: boolean;
 }
 
 export interface Channel {

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -92,6 +92,8 @@ export {
 	// Role operations
 	assignRole,
 	removeUserRole,
+	setServerMute,
+	setServerDeafen,
 
 	// Emote operations
 	uploadEmote,


### PR DESCRIPTION
### Motivation
- Provide role-gated moderator controls to forcibly mute or deafen users in voice calls so owners/admins/mods can moderate voice activity across the server.

### Description
- Backend: add server-side state (`serverMutedUsers`, `serverDeafenedUsers`), role check helper `canModerateVoice`, serializer `serializeUserForClient`, and apply/emit helpers `applyVoiceModerationState` to push authoritative state to clients. 
- Backend: add socket handlers `server-set-mute` and `server-set-deafen` which update state, broadcast `user-voice-moderation-updated` and send per-user `server-force-call-controls` / `server-voice-state-updated` events.
- Frontend: add stores `serverMuteLocked` and `serverDeafenLocked`, a `setServerVoiceState` function that enforces locks and forces local media state, and respect locks in `toggleMute`/`toggleDeafen` and UI controls.
- Frontend: wire socket listeners for `user-voice-moderation-updated`, `server-voice-state-updated`, and `server-force-call-controls`, expose emit helpers `setServerMute`/`setServerDeafen` in `socket-manager` and compatibility wrapper, and add moderator actions to the user context menu to toggle server mute/deafen.

### Testing
- Built backend with `npm run build --prefix backend` and the build completed successfully.
- Built frontend with `npm run build --prefix frontend` and the build completed successfully.
- Ran static checks with `npm run check --prefix frontend` which failed due to many pre-existing repo-wide TypeScript/Svelte issues unrelated to this change (not caused by the moderation changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e8169b9c832a976ad0176cbd1ccc)