### PR TITLE
Add media control-plane metrics, richer gateway telemetry, and process-based SRT pipeline controls

### DIFF
--- a/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
+++ b/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
@@ -5,7 +5,7 @@
 - Enable higher-quality transport/features for Tauri-native targets without breaking web compatibility.
 - Keep memory/CPU budgets low with graceful degradation.
 
-> Important: this document describes the target architecture. The current implementation only includes WebRTC-side tuning and Opus preference hints; it does **not** include a full SRT media gateway implementation yet.
+> Important: this document describes the target architecture. The current implementation includes runtime policy/heartbeat hooks and early process controls, but it does **not** yet ship a production-ready full SRT media gateway implementation.
 
 ## Transport Modes
 
@@ -28,7 +28,8 @@
 
 ### Current Status
 - ✅ WebRTC baseline improvements shipped (deafen/video-toggle fixes, sender tuning, Opus preference attempt).
-- ⚠️ SRT gateway not yet shipped (design only in this phase).
+- ⚠️ Full SRT gateway not yet shipped (design + early control hooks only in this phase).
+- ✅ Control-plane hardening in place: pipeline preset validation, URL-scheme allow-list, optional stream token checks, max-concurrency guardrails, graceful-stop escalation behavior, persisted pipeline state snapshots with optional auto-restart policy hooks, and authenticated runtime metrics exposure (`/api/media/metrics`).
 
 ## Operational Requirements (SRT Gateway)
 - Explicit ports/TLS config in deployment docs.
@@ -40,7 +41,7 @@
 1. Fix call control bugs (deafen/video-on upgrade).
 2. Stabilize WebRTC sender tuning (Opus preference + bitrate caps).
 3. Add adaptive quality ladder (resolution/fps/bitrate).
-4. Introduce gateway control hooks for SRT mode (disabled by default).
+4. Harden gateway control hooks for SRT mode (authz, restart policy, stream lifecycle cleanup).
 5. Add Tauri capability gates for enhanced mode.
 
 ## Non-Goals

--- a/backend/src/api/mediaRoutes.ts
+++ b/backend/src/api/mediaRoutes.ts
@@ -1,4 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
+import { spawn, type ChildProcess } from 'child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 function boolFromEnv(value: string | undefined, fallback: boolean = false): boolean {
 	if (value == null) return fallback;
@@ -16,11 +19,123 @@ interface GatewayHeartbeatState {
 	version?: string;
 	region?: string;
 	activeStreams?: number;
+	packetLossPct?: number;
+	jitterMs?: number;
+	rttMs?: number;
+	bitrateKbps?: number;
+	reconnections?: number;
 }
 
 const gatewayHeartbeat: GatewayHeartbeatState = {
 	lastSeenAt: 0
 };
+
+
+interface MediaGatewayMetrics {
+	pipelineStartRequests: number;
+	pipelineStopRequests: number;
+	pipelineRestarts: number;
+	pipelineErrors: number;
+	forcedKills: number;
+	lastPipelineStartAt: number | null;
+	lastPipelineStopAt: number | null;
+}
+
+const mediaGatewayMetrics: MediaGatewayMetrics = {
+	pipelineStartRequests: 0,
+	pipelineStopRequests: 0,
+	pipelineRestarts: 0,
+	pipelineErrors: 0,
+	forcedKills: 0,
+	lastPipelineStartAt: null,
+	lastPipelineStopAt: null
+};
+
+const SRT_PRESETS = ['copy', 'low-latency-720p', 'balanced-1080p'] as const;
+type SrtPreset = typeof SRT_PRESETS[number];
+
+interface SrtPipelineState {
+	pipelineId: string;
+	inputUrl: string;
+	outputUrl: string;
+	startedAt: number;
+	updatedAt: number;
+	pid: number | null;
+	status: 'starting' | 'running' | 'stopped' | 'error';
+	transcodePreset: SrtPreset;
+	restartCount: number;
+	lastExitAt?: number;
+	stopRequestedAt?: number;
+	lastError?: string;
+}
+
+const srtPipelines = new Map<string, SrtPipelineState>();
+const srtPipelineProcesses = new Map<string, ChildProcess>();
+const pipelineStateFile = process.env.MEDIA_PIPELINE_STATE_FILE || join(process.cwd(), 'data', 'media-pipelines.json');
+let mediaConfigValidated = false;
+
+function validateMediaConfigOnce(): void {
+	if (mediaConfigValidated) return;
+	mediaConfigValidated = true;
+
+	const configuredTokens = (process.env.MEDIA_PIPELINE_TOKENS || '').trim();
+	if (!configuredTokens && boolFromEnv(process.env.MEDIA_SRT_GATEWAY_ENABLED, false)) {
+		console.warn('[MediaRuntime] MEDIA_PIPELINE_TOKENS is not configured while SRT gateway mode is enabled.');
+	}
+
+	const maxPipelines = numberFromEnv(process.env.MEDIA_MAX_PIPELINES, 8);
+	if (maxPipelines <= 0) {
+		console.warn('[MediaRuntime] MEDIA_MAX_PIPELINES should be > 0. Current value will block new pipelines.');
+	}
+
+	const gatewayKey = (process.env.MEDIA_GATEWAY_KEY || '').trim();
+	if (!gatewayKey) {
+		console.warn('[MediaRuntime] MEDIA_GATEWAY_KEY is not configured; pipeline endpoints remain inaccessible.');
+	}
+
+	const restartMax = numberFromEnv(process.env.MEDIA_PIPELINE_MAX_RESTARTS, 3);
+	if (restartMax < 0) {
+		console.warn('[MediaRuntime] MEDIA_PIPELINE_MAX_RESTARTS should be >= 0.');
+	}
+}
+
+
+function loadPersistedPipelineState(): void {
+	try {
+		const raw = readFileSync(pipelineStateFile, 'utf-8');
+		const parsed = JSON.parse(raw) as { pipelines?: SrtPipelineState[] };
+		if (!Array.isArray(parsed.pipelines)) return;
+
+		for (const pipeline of parsed.pipelines) {
+			srtPipelines.set(pipeline.pipelineId, {
+				...pipeline,
+				pid: null,
+				status: pipeline.status === 'running' || pipeline.status === 'starting' ? 'stopped' : pipeline.status,
+				lastError: pipeline.status === 'running' || pipeline.status === 'starting'
+					? 'Recovered after backend restart; previous process state was reset'
+					: pipeline.lastError,
+				updatedAt: Date.now()
+			});
+		}
+	} catch {
+		// no persisted state yet
+	}
+}
+
+function persistPipelineState(): void {
+	try {
+		mkdirSync(dirname(pipelineStateFile), { recursive: true });
+		const pipelines = Array.from(srtPipelines.values()).map(pipeline => ({
+			...pipeline,
+			pid: null
+		}));
+		writeFileSync(pipelineStateFile, JSON.stringify({ pipelines }, null, 2), 'utf-8');
+	} catch (error) {
+		console.error('[MediaRuntime] Failed to persist pipeline state:', error);
+	}
+}
+
+loadPersistedPipelineState();
 
 function isGatewayAuthorized(req: IncomingMessage): boolean {
 	const configuredKey = process.env.MEDIA_GATEWAY_KEY;
@@ -29,13 +144,241 @@ function isGatewayAuthorized(req: IncomingMessage): boolean {
 	return typeof provided === 'string' && provided === configuredKey;
 }
 
+function isPipelineControlAuthorized(payload: Record<string, unknown>): boolean {
+	const configured = (process.env.MEDIA_PIPELINE_TOKENS || '')
+		.split(',')
+		.map(value => value.trim())
+		.filter(Boolean);
+	if (configured.length === 0) return true;
+	const provided = typeof payload.streamToken === 'string' ? payload.streamToken : '';
+	return configured.includes(provided);
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+	let body = '';
+	await new Promise<void>((resolve, reject) => {
+		req.on('data', chunk => {
+			body += chunk.toString();
+		});
+		req.on('end', () => resolve());
+		req.on('error', reject);
+	});
+	return body;
+}
+
+function parseJsonBody(body: string): Record<string, unknown> | null {
+	if (!body) return {};
+	try {
+		return JSON.parse(body) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+
+function numberFromPayload(payload: Record<string, unknown>, key: string): number | undefined {
+	const value = payload[key];
+	if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+	return value;
+}
+
+function getPipelineList(): SrtPipelineState[] {
+	return Array.from(srtPipelines.values()).sort((a, b) => b.startedAt - a.startedAt);
+}
+
+function isSrtPreset(value: string): value is SrtPreset {
+	return (SRT_PRESETS as readonly string[]).includes(value);
+}
+
+function isAllowedPipelineUrl(url: string): boolean {
+	const allowedSchemes = (process.env.MEDIA_ALLOWED_PIPELINE_SCHEMES || 'srt,udp,rtmp,rtmps')
+		.split(',')
+		.map(value => value.trim().toLowerCase())
+		.filter(Boolean);
+	const lower = url.toLowerCase();
+	return allowedSchemes.some(scheme => lower.startsWith(`${scheme}://`));
+}
+
+function updatePipelineState(pipelineId: string, update: Partial<SrtPipelineState>): SrtPipelineState | null {
+	const existing = srtPipelines.get(pipelineId);
+	if (!existing) return null;
+	const next = {
+		...existing,
+		...update,
+		updatedAt: Date.now()
+	};
+	srtPipelines.set(pipelineId, next);
+	persistPipelineState();
+	return next;
+}
+
+function trimPipelineHistoryIfNeeded(): void {
+	const limit = numberFromEnv(process.env.MEDIA_PIPELINE_HISTORY_LIMIT, 100);
+	if (srtPipelines.size <= limit) return;
+
+	const removable = getPipelineList()
+		.filter(pipeline => pipeline.status !== 'running' && pipeline.status !== 'starting')
+		.sort((a, b) => a.updatedAt - b.updatedAt);
+
+	for (const pipeline of removable) {
+		if (srtPipelines.size <= limit) break;
+		srtPipelines.delete(pipeline.pipelineId);
+	}
+	persistPipelineState();
+}
+
+function buildFfmpegArgs(inputUrl: string, outputUrl: string, preset: SrtPreset): string[] {
+	if (preset === 'copy') {
+		return ['-re', '-i', inputUrl, '-c', 'copy', '-f', 'mpegts', outputUrl];
+	}
+
+	if (preset === 'low-latency-720p') {
+		return [
+			'-re', '-i', inputUrl,
+			'-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency', '-profile:v', 'main',
+			'-vf', 'scale=-2:720',
+			'-b:v', '2500k',
+			'-c:a', 'aac', '-b:a', '128k',
+			'-f', 'mpegts', outputUrl
+		];
+	}
+
+	return [
+		'-re', '-i', inputUrl,
+		'-c:v', 'libx264', '-preset', 'medium', '-profile:v', 'high',
+		'-b:v', '4500k',
+		'-c:a', 'aac', '-b:a', '160k',
+		'-f', 'mpegts', outputUrl
+	];
+}
+
+function shouldAttemptRestart(pipeline: SrtPipelineState, exitCode: number | null): boolean {
+	if (!boolFromEnv(process.env.MEDIA_PIPELINE_AUTO_RESTART_ENABLED, false)) return false;
+	if (pipeline.stopRequestedAt && pipeline.stopRequestedAt > pipeline.startedAt) return false;
+	if (exitCode === 0) return false;
+	const maxRestarts = numberFromEnv(process.env.MEDIA_PIPELINE_MAX_RESTARTS, 3);
+	return pipeline.restartCount < maxRestarts;
+}
+
+function spawnPipelineProcess(pipelineId: string): boolean {
+	const pipeline = srtPipelines.get(pipelineId);
+	if (!pipeline) return false;
+
+	const ffmpegPath = process.env.MEDIA_FFMPEG_BIN || 'ffmpeg';
+	const ffmpegArgs = buildFfmpegArgs(pipeline.inputUrl, pipeline.outputUrl, pipeline.transcodePreset);
+	const child = spawn(ffmpegPath, ffmpegArgs, {
+		stdio: 'ignore',
+		detached: false
+	});
+
+	srtPipelineProcesses.set(pipelineId, child);
+	updatePipelineState(pipelineId, {
+		pid: child.pid ?? null,
+		status: child.pid ? 'running' : 'starting',
+		lastError: undefined,
+		stopRequestedAt: undefined
+	});
+
+	child.once('spawn', () => {
+		updatePipelineState(pipelineId, {
+			status: 'running',
+			pid: child.pid ?? null,
+			lastError: undefined
+		});
+	});
+
+	child.once('error', error => {
+		mediaGatewayMetrics.pipelineErrors += 1;
+		updatePipelineState(pipelineId, {
+			status: 'error',
+			lastError: error.message,
+			pid: null,
+			lastExitAt: Date.now()
+		});
+		srtPipelineProcesses.delete(pipelineId);
+		trimPipelineHistoryIfNeeded();
+	});
+
+	child.once('exit', (code, signal) => {
+		const existing = srtPipelines.get(pipelineId);
+		srtPipelineProcesses.delete(pipelineId);
+		if (!existing) return;
+
+		if (shouldAttemptRestart(existing, code)) {
+			const restartDelayMs = numberFromEnv(process.env.MEDIA_PIPELINE_RESTART_DELAY_MS, 750);
+			mediaGatewayMetrics.pipelineRestarts += 1;
+			updatePipelineState(pipelineId, {
+				status: 'starting',
+				pid: null,
+				restartCount: existing.restartCount + 1,
+				lastExitAt: Date.now(),
+				lastError: `Restarting after exit code ${code ?? 'null'} signal ${signal ?? 'null'}`
+			});
+			setTimeout(() => {
+				const current = srtPipelines.get(pipelineId);
+				if (!current || current.status === 'stopped') return;
+				try {
+					spawnPipelineProcess(pipelineId);
+				} catch (restartError) {
+					updatePipelineState(pipelineId, {
+						status: 'error',
+						lastError: restartError instanceof Error ? restartError.message : String(restartError),
+						pid: null,
+						lastExitAt: Date.now()
+					});
+				}
+			}, restartDelayMs);
+			return;
+		}
+
+		if (code !== 0) {
+			mediaGatewayMetrics.pipelineErrors += 1;
+		}
+		updatePipelineState(pipelineId, {
+			status: code === 0 ? 'stopped' : 'error',
+			lastError: code === 0 ? undefined : `Exited with code ${code ?? 'null'} signal ${signal ?? 'null'}`,
+			pid: null,
+			lastExitAt: Date.now()
+		});
+		trimPipelineHistoryIfNeeded();
+	});
+
+	return true;
+}
+
+async function stopProcessGracefully(processHandle: ChildProcess, timeoutMs: number): Promise<{ stopped: boolean; escalated: boolean }> {
+	const pid = processHandle.pid;
+	if (!pid) return { stopped: true, escalated: false };
+
+	const terminated = processHandle.kill('SIGTERM');
+	if (!terminated) {
+		return { stopped: false, escalated: false };
+	}
+
+	const waitForExit = new Promise<boolean>(resolve => {
+		const timer = setTimeout(() => resolve(false), timeoutMs);
+		processHandle.once('exit', () => {
+			clearTimeout(timer);
+			resolve(true);
+		});
+	});
+
+	const exitedInTime = await waitForExit;
+	if (exitedInTime) {
+		return { stopped: true, escalated: false };
+	}
+
+	processHandle.kill('SIGKILL');
+	return { stopped: true, escalated: true };
+}
 
 // GET /api/media/runtime
-// Provides server runtime hints for media quality transport paths.
 export async function handleGetMediaRuntime(req: IncomingMessage, res: ServerResponse): Promise<void> {
 	try {
+		validateMediaConfigOnce();
 		const srtGatewayEnabled = boolFromEnv(process.env.MEDIA_SRT_GATEWAY_ENABLED, false);
 		const localEnhancedEnabled = boolFromEnv(process.env.MEDIA_LOCAL_ENHANCED_ENABLED, true);
+		const heartbeatTimeoutMs = numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000);
 
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({
@@ -49,12 +392,27 @@ export async function handleGetMediaRuntime(req: IncomingMessage, res: ServerRes
 				},
 				gateway: {
 					configured: Boolean(process.env.MEDIA_SRT_GATEWAY_URL),
-					heartbeatTimeoutMs: numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000),
-					healthy: gatewayHeartbeat.lastSeenAt > 0 && Date.now() - gatewayHeartbeat.lastSeenAt < numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000),
+					heartbeatTimeoutMs,
+					healthy: gatewayHeartbeat.lastSeenAt > 0 && Date.now() - gatewayHeartbeat.lastSeenAt < heartbeatTimeoutMs,
 					lastSeenAt: gatewayHeartbeat.lastSeenAt || null,
 					activeStreams: gatewayHeartbeat.activeStreams ?? 0,
 					version: gatewayHeartbeat.version || null,
-					region: gatewayHeartbeat.region || null
+					region: gatewayHeartbeat.region || null,
+					transportMetrics: {
+						packetLossPct: gatewayHeartbeat.packetLossPct ?? null,
+						jitterMs: gatewayHeartbeat.jitterMs ?? null,
+						rttMs: gatewayHeartbeat.rttMs ?? null,
+						bitrateKbps: gatewayHeartbeat.bitrateKbps ?? null,
+						reconnections: gatewayHeartbeat.reconnections ?? null
+					},
+					pipelines: {
+						active: getPipelineList().filter(pipeline => pipeline.status === 'running').length,
+						total: srtPipelines.size,
+						availablePresets: [...SRT_PRESETS],
+						maxConfigured: numberFromEnv(process.env.MEDIA_MAX_PIPELINES, 8),
+						autoRestartEnabled: boolFromEnv(process.env.MEDIA_PIPELINE_AUTO_RESTART_ENABLED, false)
+					},
+					controlPlaneMetrics: mediaGatewayMetrics
 				}
 			},
 			notes: {
@@ -69,9 +427,7 @@ export async function handleGetMediaRuntime(req: IncomingMessage, res: ServerRes
 	}
 }
 
-
 // POST /api/media/gateway-heartbeat
-// Optional SRT gateway can report health/stream load to backend.
 export async function handleMediaGatewayHeartbeat(req: IncomingMessage, res: ServerResponse): Promise<void> {
 	if (!isGatewayAuthorized(req)) {
 		res.writeHead(401, { 'Content-Type': 'application/json' });
@@ -79,31 +435,230 @@ export async function handleMediaGatewayHeartbeat(req: IncomingMessage, res: Ser
 		return;
 	}
 
-	let body = '';
-	await new Promise<void>((resolve, reject) => {
-		req.on('data', chunk => {
-			body += chunk.toString();
-		});
-		req.on('end', () => resolve());
-		req.on('error', reject);
-	});
 
-	let payload: Record<string, unknown> = {};
-	if (body) {
-		try {
-			payload = JSON.parse(body);
-		} catch {
-			res.writeHead(400, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ error: 'Invalid JSON in gateway heartbeat' }));
-			return;
-		}
+	const body = await readRequestBody(req);
+	const payload = parseJsonBody(body);
+	if (!payload) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Invalid JSON in gateway heartbeat' }));
+		return;
 	}
 
 	gatewayHeartbeat.lastSeenAt = Date.now();
 	gatewayHeartbeat.version = typeof payload.version === 'string' ? payload.version : undefined;
 	gatewayHeartbeat.region = typeof payload.region === 'string' ? payload.region : undefined;
 	gatewayHeartbeat.activeStreams = typeof payload.activeStreams === 'number' ? payload.activeStreams : 0;
+	gatewayHeartbeat.packetLossPct = numberFromPayload(payload, 'packetLossPct');
+	gatewayHeartbeat.jitterMs = numberFromPayload(payload, 'jitterMs');
+	gatewayHeartbeat.rttMs = numberFromPayload(payload, 'rttMs');
+	gatewayHeartbeat.bitrateKbps = numberFromPayload(payload, 'bitrateKbps');
+	gatewayHeartbeat.reconnections = numberFromPayload(payload, 'reconnections');
 
 	res.writeHead(200, { 'Content-Type': 'application/json' });
 	res.end(JSON.stringify({ ok: true }));
+}
+
+// GET /api/media/pipelines
+export async function handleListMediaPipelines(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		res.writeHead(401, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Unauthorized gateway pipeline access' }));
+		return;
+	}
+
+	res.writeHead(200, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify({ pipelines: getPipelineList() }));
+}
+
+
+// GET /api/media/metrics
+export async function handleGetMediaMetrics(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		res.writeHead(401, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Unauthorized media metrics access' }));
+		return;
+	}
+
+	res.writeHead(200, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify({
+		metrics: mediaGatewayMetrics,
+		pipelines: getPipelineList()
+	}));
+}
+
+// POST /api/media/pipelines/start
+export async function handleStartMediaPipeline(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		res.writeHead(401, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Unauthorized gateway pipeline start' }));
+		return;
+	}
+
+	mediaGatewayMetrics.pipelineStartRequests += 1;
+	mediaGatewayMetrics.lastPipelineStartAt = Date.now();
+
+	const body = await readRequestBody(req);
+	const payload = parseJsonBody(body);
+	if (!payload) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
+		return;
+	}
+
+	if (!isPipelineControlAuthorized(payload)) {
+		res.writeHead(403, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Invalid or missing stream token' }));
+		return;
+	}
+
+	const pipelineId = typeof payload.pipelineId === 'string' ? payload.pipelineId.trim() : '';
+	const inputUrl = typeof payload.inputUrl === 'string' ? payload.inputUrl.trim() : '';
+	const outputUrl = typeof payload.outputUrl === 'string' ? payload.outputUrl.trim() : '';
+	const transcodePresetInput = typeof payload.transcodePreset === 'string' ? payload.transcodePreset : 'balanced-1080p';
+
+	if (!pipelineId || !inputUrl || !outputUrl) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'pipelineId, inputUrl, and outputUrl are required' }));
+		return;
+	}
+
+	if (!isAllowedPipelineUrl(inputUrl) || !isAllowedPipelineUrl(outputUrl)) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Only configured media URL schemes are allowed for pipeline URLs' }));
+		return;
+	}
+
+	if (!isSrtPreset(transcodePresetInput)) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: `Invalid transcodePreset. Allowed: ${SRT_PRESETS.join(', ')}` }));
+		return;
+	}
+
+	const maxPipelines = numberFromEnv(process.env.MEDIA_MAX_PIPELINES, 8);
+	const runningCount = getPipelineList().filter(pipeline => pipeline.status === 'running' || pipeline.status === 'starting').length;
+	if (runningCount >= maxPipelines) {
+		res.writeHead(429, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: `Maximum concurrent pipelines reached (${maxPipelines})` }));
+		return;
+	}
+
+	const existingPipeline = srtPipelines.get(pipelineId);
+	if (existingPipeline?.status === 'running' || existingPipeline?.status === 'starting') {
+		res.writeHead(409, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Pipeline is already running', pipeline: existingPipeline }));
+		return;
+	}
+
+	const now = Date.now();
+	srtPipelines.set(pipelineId, {
+		pipelineId,
+		inputUrl,
+		outputUrl,
+		startedAt: now,
+		updatedAt: now,
+		pid: null,
+		status: 'starting',
+		transcodePreset: transcodePresetInput,
+		restartCount: 0,
+		lastError: undefined,
+		lastExitAt: undefined,
+		stopRequestedAt: undefined
+	});
+	persistPipelineState();
+
+	try {
+		const spawned = spawnPipelineProcess(pipelineId);
+		if (!spawned) {
+			res.writeHead(500, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Failed to initialize pipeline process' }));
+			return;
+		}
+
+		res.writeHead(202, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ ok: true, pipeline: srtPipelines.get(pipelineId) }));
+	} catch (error) {
+		srtPipelineProcesses.delete(pipelineId);
+		updatePipelineState(pipelineId, {
+			status: 'error',
+			lastError: error instanceof Error ? error.message : String(error),
+			pid: null,
+			lastExitAt: Date.now()
+		});
+		trimPipelineHistoryIfNeeded();
+		console.error('[MediaRuntime] Failed to spawn FFmpeg pipeline:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to start media pipeline' }));
+	}
+}
+
+// POST /api/media/pipelines/stop
+export async function handleStopMediaPipeline(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		res.writeHead(401, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Unauthorized gateway pipeline stop' }));
+		return;
+	}
+
+	mediaGatewayMetrics.pipelineStopRequests += 1;
+	mediaGatewayMetrics.lastPipelineStopAt = Date.now();
+
+	const body = await readRequestBody(req);
+	const payload = parseJsonBody(body);
+	if (!payload) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
+		return;
+	}
+
+	if (!isPipelineControlAuthorized(payload)) {
+		res.writeHead(403, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Invalid or missing stream token' }));
+		return;
+	}
+
+	const pipelineId = typeof payload.pipelineId === 'string' ? payload.pipelineId.trim() : '';
+	if (!pipelineId) {
+		res.writeHead(400, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'pipelineId is required' }));
+		return;
+	}
+
+	const processHandle = srtPipelineProcesses.get(pipelineId);
+	const existingPipeline = srtPipelines.get(pipelineId);
+	if (!existingPipeline) {
+		res.writeHead(404, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Pipeline not found' }));
+		return;
+	}
+
+	if (!processHandle) {
+		updatePipelineState(pipelineId, {
+			status: 'stopped',
+			pid: null,
+			stopRequestedAt: Date.now()
+		});
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ ok: true, pipeline: srtPipelines.get(pipelineId), alreadyStopped: true }));
+		return;
+	}
+
+	const stopTimeoutMs = numberFromEnv(process.env.MEDIA_PIPELINE_STOP_TIMEOUT_MS, 4_000);
+	updatePipelineState(pipelineId, { stopRequestedAt: Date.now() });
+	const { stopped, escalated } = await stopProcessGracefully(processHandle, stopTimeoutMs);
+	if (escalated) mediaGatewayMetrics.forcedKills += 1;
+	srtPipelineProcesses.delete(pipelineId);
+	updatePipelineState(pipelineId, {
+		status: 'stopped',
+		pid: null,
+		lastError: stopped ? undefined : 'Failed to stop pipeline process',
+		lastExitAt: Date.now()
+	});
+	trimPipelineHistoryIfNeeded();
+
+	res.writeHead(stopped ? 200 : 500, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify({
+		ok: stopped,
+		escalatedToSigkill: escalated,
+		pipeline: srtPipelines.get(pipelineId)
+	}));
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,7 +17,7 @@ import { verifyToken } from "./auth/jwt.js";
 import { handleRegister, handleLogin, handleUpgrade, handleGetUserSettings, handleSaveUserSettings, handleGetPublicKey, handleStoreEncryptionKeys } from "./api/authRoutes.js";
 import { handleGetThemePreferences, handleSaveThemePreferences, handleResetThemePreferences } from "./api/themeRoutes.js";
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
-import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
+import { handleGetMediaRuntime, handleMediaGatewayHeartbeat, handleListMediaPipelines, handleStartMediaPipeline, handleStopMediaPipeline, handleGetMediaMetrics } from "./api/mediaRoutes.js";
 import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handleListWebhookDeliveries } from "./api/webhookRoutes.js";
 import { relayRepository } from "./db/repositories/relayRepository.js";
 import { corsCallback, getCORSHeaders, getAllowedOrigins, isOriginAllowed } from "./config/cors.js";
@@ -1005,6 +1005,26 @@ server.on('request', async (req, res) => {
 
   if (url.pathname === "/api/media/gateway-heartbeat" && req.method === "POST") {
     await handleMediaGatewayHeartbeat(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/pipelines" && req.method === "GET") {
+    await handleListMediaPipelines(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/metrics" && req.method === "GET") {
+    await handleGetMediaMetrics(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/pipelines/start" && req.method === "POST") {
+    await handleStartMediaPipeline(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/pipelines/stop" && req.method === "POST") {
+    await handleStopMediaPipeline(req, res);
     return;
   }
 

--- a/frontend/src-tauri/src/handlers.rs
+++ b/frontend/src-tauri/src/handlers.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
+use std::time::Duration;
 use tauri::{AppHandle, Manager};
 
 #[derive(Default)]
@@ -10,6 +12,9 @@ pub struct SrtGatewayState {
     pub running: bool,
     pub mode: String,
     pub updated_at: i64,
+    pub process: Option<Child>,
+    pub pid: Option<u32>,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -32,6 +37,48 @@ pub struct SrtGatewayRuntimeState {
     pub running: bool,
     pub mode: String,
     pub updated_at: i64,
+    pub pid: Option<u32>,
+    pub last_error: Option<String>,
+}
+
+fn runtime_state_from_guard(guard: &SrtGatewayState) -> SrtGatewayRuntimeState {
+    SrtGatewayRuntimeState {
+        running: guard.running,
+        mode: guard.mode.clone(),
+        updated_at: guard.updated_at,
+        pid: guard.pid,
+        last_error: guard.last_error.clone(),
+    }
+}
+
+fn refresh_srt_gateway_state(guard: &mut SrtGatewayState) {
+    let mut exited = false;
+
+    if let Some(child) = guard.process.as_mut() {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                exited = true;
+                guard.last_error = if status.success() {
+                    None
+                } else {
+                    Some(format!("gateway process exited with status: {status}"))
+                };
+            }
+            Ok(None) => {}
+            Err(error) => {
+                exited = true;
+                guard.last_error = Some(format!("failed checking srt gateway process: {error}"));
+            }
+        }
+    }
+
+    if exited {
+        guard.process = None;
+        guard.pid = None;
+        guard.running = false;
+        guard.mode = "idle".to_string();
+        guard.updated_at = chrono::Utc::now().timestamp_millis();
+    }
 }
 
 fn app_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
@@ -173,38 +220,67 @@ pub fn get_media_transport_preferences(app: AppHandle) -> Result<MediaTransportP
 
 #[tauri::command]
 pub fn get_srt_gateway_runtime_state(state: tauri::State<Mutex<SrtGatewayState>>) -> Result<SrtGatewayRuntimeState, String> {
-    let guard = state.lock().map_err(|_| "failed to lock srt gateway state".to_string())?;
-    Ok(SrtGatewayRuntimeState {
-        running: guard.running,
-        mode: guard.mode.clone(),
-        updated_at: guard.updated_at,
-    })
+    let mut guard = state.lock().map_err(|_| "failed to lock srt gateway state".to_string())?;
+    refresh_srt_gateway_state(&mut guard);
+    Ok(runtime_state_from_guard(&guard))
 }
 
 #[tauri::command]
-pub fn start_srt_gateway_simulation(state: tauri::State<Mutex<SrtGatewayState>>) -> Result<SrtGatewayRuntimeState, String> {
+pub fn start_srt_gateway(state: tauri::State<Mutex<SrtGatewayState>>) -> Result<SrtGatewayRuntimeState, String> {
     let mut guard = state.lock().map_err(|_| "failed to lock srt gateway state".to_string())?;
+    refresh_srt_gateway_state(&mut guard);
+    if guard.running {
+        return Ok(runtime_state_from_guard(&guard));
+    }
+
+    let executable = std::env::var("WABI_SRT_GATEWAY_BIN").unwrap_or_else(|_| "ffmpeg".to_string());
+    let input = std::env::var("WABI_SRT_GATEWAY_INPUT").unwrap_or_else(|_| "srt://0.0.0.0:9000?mode=listener".to_string());
+    let output = std::env::var("WABI_SRT_GATEWAY_OUTPUT").unwrap_or_else(|_| "srt://127.0.0.1:9001?mode=caller".to_string());
+
+    let child = Command::new(executable)
+        .args(["-re", "-i", input.as_str(), "-c", "copy", "-f", "mpegts", output.as_str()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn srt gateway process: {e}"))?;
+
+    guard.pid = Some(child.id());
+    guard.process = Some(child);
     guard.running = true;
-    guard.mode = "simulated".to_string();
+    guard.mode = "process".to_string();
     guard.updated_at = chrono::Utc::now().timestamp_millis();
+    guard.last_error = None;
 
-    Ok(SrtGatewayRuntimeState {
-        running: guard.running,
-        mode: guard.mode.clone(),
-        updated_at: guard.updated_at,
-    })
+    Ok(runtime_state_from_guard(&guard))
 }
 
 #[tauri::command]
-pub fn stop_srt_gateway_simulation(state: tauri::State<Mutex<SrtGatewayState>>) -> Result<SrtGatewayRuntimeState, String> {
+pub fn stop_srt_gateway(state: tauri::State<Mutex<SrtGatewayState>>) -> Result<SrtGatewayRuntimeState, String> {
     let mut guard = state.lock().map_err(|_| "failed to lock srt gateway state".to_string())?;
+    refresh_srt_gateway_state(&mut guard);
+
+    if let Some(mut child) = guard.process.take() {
+        match child.kill() {
+            Ok(_) => {
+                std::thread::sleep(Duration::from_millis(250));
+                if let Ok(None) = child.try_wait() {
+                    let _ = child.kill();
+                    guard.last_error = Some("srt gateway stop required force kill".to_string());
+                } else {
+                    guard.last_error = None;
+                }
+            }
+            Err(error) => {
+                guard.last_error = Some(format!("failed to stop srt gateway process: {error}"));
+            }
+        }
+    }
+
     guard.running = false;
     guard.mode = "idle".to_string();
     guard.updated_at = chrono::Utc::now().timestamp_millis();
+    guard.pid = None;
 
-    Ok(SrtGatewayRuntimeState {
-        running: guard.running,
-        mode: guard.mode.clone(),
-        updated_at: guard.updated_at,
-    })
+    Ok(runtime_state_from_guard(&guard))
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ use handlers::{
     save_burndown_chart, load_burndown_chart, save_reminders, load_reminders,
     delete_reminders, get_data_stats, clear_binary_data,
     get_media_runtime_capabilities, set_media_transport_preferences, get_media_transport_preferences,
-    get_srt_gateway_runtime_state, start_srt_gateway_simulation, stop_srt_gateway_simulation,
+    get_srt_gateway_runtime_state, start_srt_gateway, stop_srt_gateway,
     SrtGatewayState
 };
 use std::sync::Mutex;
@@ -18,6 +18,9 @@ fn main() {
             running: false,
             mode: "idle".to_string(),
             updated_at: chrono::Utc::now().timestamp_millis(),
+            process: None,
+            pid: None,
+            last_error: None,
         }))
         .invoke_handler(tauri::generate_handler![
             save_burndown_chart,
@@ -31,8 +34,8 @@ fn main() {
             set_media_transport_preferences,
             get_media_transport_preferences,
             get_srt_gateway_runtime_state,
-            start_srt_gateway_simulation,
-            stop_srt_gateway_simulation
+            start_srt_gateway,
+            stop_srt_gateway
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/frontend/src/lib/tauri-media.ts
+++ b/frontend/src/lib/tauri-media.ts
@@ -16,8 +16,10 @@ export interface MediaTransportPreferences {
 
 export interface SrtGatewayRuntimeState {
 	running: boolean;
-	mode: 'idle' | 'simulated';
+	mode: 'idle' | 'process';
 	updated_at: number;
+	pid?: number | null;
+	last_error?: string | null;
 }
 
 function isTauriAvailable(): boolean {
@@ -63,22 +65,22 @@ export async function getTauriSrtGatewayState(): Promise<SrtGatewayRuntimeState 
 	}
 }
 
-export async function startTauriSrtGatewaySimulation(): Promise<SrtGatewayRuntimeState | null> {
+export async function startTauriSrtGateway(): Promise<SrtGatewayRuntimeState | null> {
 	if (!isDesktopTauri()) return null;
 	try {
-		return await invoke<SrtGatewayRuntimeState>('start_srt_gateway_simulation');
+		return await invoke<SrtGatewayRuntimeState>('start_srt_gateway');
 	} catch (error) {
-		console.warn('[Tauri Media] Could not start SRT gateway simulation:', error);
+		console.warn('[Tauri Media] Could not start SRT gateway:', error);
 		return null;
 	}
 }
 
-export async function stopTauriSrtGatewaySimulation(): Promise<SrtGatewayRuntimeState | null> {
+export async function stopTauriSrtGateway(): Promise<SrtGatewayRuntimeState | null> {
 	if (!isDesktopTauri()) return null;
 	try {
-		return await invoke<SrtGatewayRuntimeState>('stop_srt_gateway_simulation');
+		return await invoke<SrtGatewayRuntimeState>('stop_srt_gateway');
 	} catch (error) {
-		console.warn('[Tauri Media] Could not stop SRT gateway simulation:', error);
+		console.warn('[Tauri Media] Could not stop SRT gateway:', error);
 		return null;
 	}
 }


### PR DESCRIPTION
### Motivation
- Harden the server-side SRT control plane for production by improving observability, adding guarded restart behavior, and providing operator-facing metrics. 
- Make Tauri-side SRT controls real (process-based) instead of simulated so native deployments can start/stop gateway processes and report PID/error state.

### Description
- Added in-memory control-plane metrics aggregation (`pipelineStartRequests`, `pipelineStopRequests`, `pipelineRestarts`, `pipelineErrors`, `forcedKills`, last start/stop timestamps`) and a new authenticated endpoint `GET /api/media/metrics` to expose them (`backend/src/api/mediaRoutes.ts`).
- Extended heartbeat telemetry with transport fields (`packetLossPct`, `jitterMs`, `rttMs`, `bitrateKbps`, `reconnections`) and surfaced these via `/api/media/runtime` for operator visibility (`backend/src/api/mediaRoutes.ts`).
- Expanded pipeline lifecycle handling: persistent pipeline snapshot loading/saving, normalized recovered states after backend restart, FFmpeg spawn/exit handling, graceful stop with SIGKILL escalation, auto-restart policy hooks, and restart/trim helpers; also added `GET /api/media/pipelines`, `POST /api/media/pipelines/start`, and `POST /api/media/pipelines/stop` control endpoints and related validations (presets, URL-scheme allow-list, token checks) (`backend/src/api/mediaRoutes.ts`, `backend/src/server.ts`).
- Implemented Tauri-side process controls and richer runtime state: actual `start_srt_gateway`/`stop_srt_gateway` now spawn/kill a child process, track `pid` and `last_error`, switch runtime `mode` to `process`, and updated JS client helpers/types to match (`frontend/src-tauri/src/handlers.rs`, `frontend/src-tauri/src/main.rs`, `frontend/src/lib/tauri-media.ts`).
- Updated architecture doc to include authenticated metrics exposure as part of control-plane hardening (`PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md`).

### Testing
- Ran backend build with `npm --prefix backend run build` which produced `dist/server.js` and succeeded.
- Ran `cargo check` in `frontend/src-tauri` which failed due to missing native system dependency (`glib-2.0.pc` / `glib-2.0`) in the environment, so Tauri Rust checks could not complete.
- Verified routing registration by adding `GET /api/media/metrics` and pipeline routes to `backend/src/server.ts` and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699046df16bc832a9db7b180f368e40d)