### PR TITLE
Sanction evasion enforcement: DB tracking, server checks, and frontend appeal gate

### DIFF
--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -145,6 +145,23 @@ function runMigrations() {
 		// Columns may already exist
 	}
 
+
+	// Migration: Add sanctions table for evasion tracking
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS user_sanctions (
+				user_id INTEGER PRIMARY KEY,
+				is_sanctioned INTEGER NOT NULL DEFAULT 0,
+				evasion_count INTEGER NOT NULL DEFAULT 0,
+				appeal_required INTEGER NOT NULL DEFAULT 0,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+			)
+		`);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_user_sanctions_appeal_required ON user_sanctions(appeal_required)');
+	} catch (e) {
+		console.error('[Database] Migration error creating user_sanctions table:', e);
+	}
 	// Migration: Add encryption columns to messages table
 	try {
 		const cols = db.pragma('table_info(messages)') as { name: string }[];

--- a/backend/src/db/repositories/userSanctionRepository.ts
+++ b/backend/src/db/repositories/userSanctionRepository.ts
@@ -1,0 +1,44 @@
+import db from '../database.js';
+
+export interface UserSanction {
+	user_id: number;
+	is_sanctioned: number;
+	evasion_count: number;
+	appeal_required: number;
+	updated_at: number;
+}
+
+export class UserSanctionRepository {
+	findByUserId(userId: number): UserSanction | null {
+		const stmt = db.prepare('SELECT * FROM user_sanctions WHERE user_id = ?');
+		return (stmt.get(userId) as UserSanction) || null;
+	}
+
+	recordEvasionAttempt(userId: number): UserSanction {
+		const now = Date.now();
+		db.prepare(`
+			INSERT INTO user_sanctions (user_id, is_sanctioned, evasion_count, appeal_required, updated_at)
+			VALUES (?, 1, 0, 0, ?)
+			ON CONFLICT(user_id) DO UPDATE SET
+				is_sanctioned = 1,
+				updated_at = excluded.updated_at
+		`).run(userId, now);
+
+		db.prepare(`
+			UPDATE user_sanctions
+			SET
+				evasion_count = evasion_count + 1,
+				appeal_required = CASE WHEN evasion_count + 1 >= 2 THEN 1 ELSE appeal_required END,
+				updated_at = ?
+			WHERE user_id = ?
+		`).run(now, userId);
+
+		const sanction = this.findByUserId(userId);
+		if (!sanction) {
+			throw new Error(`Failed to load sanctions for user ${userId}`);
+		}
+		return sanction;
+	}
+}
+
+export const userSanctionRepository = new UserSanctionRepository();

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -125,6 +125,16 @@ CREATE TABLE IF NOT EXISTS guest_codes (
   FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
 );
 
+-- Sanctions / evasion tracking
+CREATE TABLE IF NOT EXISTS user_sanctions (
+  user_id INTEGER PRIMARY KEY,
+  is_sanctioned INTEGER NOT NULL DEFAULT 0,
+  evasion_count INTEGER NOT NULL DEFAULT 0,
+  appeal_required INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_offline_messages_to_user ON offline_messages(to_user_id, delivered);
@@ -134,6 +144,7 @@ CREATE INDEX IF NOT EXISTS idx_users_handle ON users(handle COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_user_roles_user ON user_roles(user_id);
 CREATE INDEX IF NOT EXISTS idx_resource_visibility_resource ON resource_visibility(resource_id);
 CREATE INDEX IF NOT EXISTS idx_guest_codes_active ON guest_codes(is_active);
+CREATE INDEX IF NOT EXISTS idx_user_sanctions_appeal_required ON user_sanctions(appeal_required);
 
 -- Initial guest code
 INSERT OR IGNORE INTO guest_codes (code, description, is_active)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import { __dirname } from "./_dirname.js";
 import db, { initializeDatabase, closeDatabase } from "./db/database.js";
 import { userRepository } from "./db/repositories/userRepository.js";
 import { sessionRepository } from "./db/repositories/sessionRepository.js";
+import { userSanctionRepository } from "./db/repositories/userSanctionRepository.js";
 import { offlineMessageRepository } from "./db/repositories/offlineMessageRepository.js";
 import { settingsRepository } from "./db/repositories/settingsRepository.js";
 import { themeRepository } from "./db/repositories/themeRepository.js";
@@ -2273,6 +2274,32 @@ pluginLoader.loadAll().then(() => {
   console.error('❌ Failed to load plugins:', error);
 });
 
+interface SanctionCheckResult {
+  blocked: boolean;
+  reason?: 'force_logout' | 'appeal_required';
+}
+
+function processSanctionEvasion(dbUserId?: number, sessionId?: string): SanctionCheckResult {
+  if (!dbUserId) return { blocked: false };
+
+  const sanction = userSanctionRepository.findByUserId(dbUserId);
+  if (!sanction || !sanction.is_sanctioned) {
+    return { blocked: false };
+  }
+
+  const updatedSanction = userSanctionRepository.recordEvasionAttempt(dbUserId);
+
+  if (updatedSanction.evasion_count >= 2 || updatedSanction.appeal_required) {
+    return { blocked: true, reason: 'appeal_required' };
+  }
+
+  if (sessionId) {
+    sessionRepository.delete(sessionId);
+  }
+
+  return { blocked: true, reason: 'force_logout' };
+}
+
 // Socket.IO middleware to validate sessions (temp and registered users)
 io.use((socket, next) => {
   const token = socket.handshake.auth.token;
@@ -2286,6 +2313,11 @@ io.use((socket, next) => {
 
       if (!dbSession || (dbSession.expires_at && dbSession.expires_at < Date.now())) {
         return next(new Error('Session expired'));
+      }
+
+      const sanction = userSanctionRepository.findByUserId(payload.userId);
+      if (sanction?.is_sanctioned && sanction.appeal_required) {
+        return next(new Error('appeal_required'));
       }
 
       (socket as any).sessionId = payload.sessionId;
@@ -2368,6 +2400,17 @@ io.on("connection", (socket) => {
       const dbSession = sessionRepository.findById((socket as any).sessionId);
 
       if (dbSession) {
+        const sanctionCheck = processSanctionEvasion((socket as any).dbUserId, (socket as any).sessionId);
+        if (sanctionCheck.blocked) {
+          if (sanctionCheck.reason === 'appeal_required') {
+            socket.emit('appeal_required', { state: 'appeal_required' });
+          } else {
+            socket.emit('force-logout', { reason: 'sanction_evasion' });
+          }
+          socket.disconnect(true);
+          return;
+        }
+
         // Use the registered user's data from the database
         const registeredUsername = dbSession.username;
         const registeredColor = dbSession.color || `#${Math.floor(Math.random()*16777215).toString(16)}`;
@@ -2568,6 +2611,17 @@ io.on("connection", (socket) => {
     const session = sessions.get(sessionId);
     if (!session) {
       socket.emit("rejoin-failed", { reason: "Invalid session" });
+      return;
+    }
+
+    const rejoinSanctionCheck = processSanctionEvasion((socket as any).dbUserId, (socket as any).sessionId);
+    if (rejoinSanctionCheck.blocked) {
+      if (rejoinSanctionCheck.reason === 'appeal_required') {
+        socket.emit('appeal_required', { state: 'appeal_required' });
+      } else {
+        socket.emit('force-logout', { reason: 'sanction_evasion' });
+      }
+      socket.disconnect(true);
       return;
     }
 

--- a/frontend/src/lib/authStore.ts
+++ b/frontend/src/lib/authStore.ts
@@ -7,18 +7,20 @@ import { writable } from 'svelte/store';
 
 export interface AuthError {
 	message: string;
-	type: 'session_expired' | 'invalid_token' | 'auth_failed' | 'connection_lost';
+	type: 'session_expired' | 'invalid_token' | 'auth_failed' | 'connection_lost' | 'appeal_required';
 	timestamp: number;
 }
 
 interface AuthState {
 	error: AuthError | null;
 	isAuthError: boolean;
+	appealRequired: boolean;
 }
 
 const initialState: AuthState = {
 	error: null,
-	isAuthError: false
+	isAuthError: false,
+	appealRequired: false
 };
 
 function createAuthStore() {
@@ -37,10 +39,27 @@ function createAuthStore() {
 					type,
 					timestamp: Date.now()
 				},
-				isAuthError: true
+				isAuthError: true,
+				appealRequired: false
 			});
 		},
 
+
+		setAppealRequired() {
+			set({
+				error: {
+					message: 'Account access restricted pending appeal.',
+					type: 'appeal_required',
+					timestamp: Date.now()
+				},
+				isAuthError: true,
+				appealRequired: true
+			});
+		},
+
+		clearAppealRequired() {
+			update(state => ({ ...state, appealRequired: false }));
+		},
 		/**
 		 * Clear the auth error
 		 */

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -18,6 +18,7 @@
 
 	let qrCanvas: HTMLCanvasElement;
 	let showQR = false;
+	export let appealRequired = false;
 	let customRoom = '';
 
 	// Auto-detect current origin
@@ -139,6 +140,16 @@
 		if (room) customRoom = room;
 	});
 </script>
+
+{#if appealRequired}
+	<div class="login-container">
+		<div class="login-box appeal-box">
+			<h2>Appeal Required</h2>
+			<p>Your account is currently restricted. Submit an appeal to restore access.</p>
+			<a class="appeal-link" href="mailto:appeals@wabi.chat?subject=Appeal%20Request">Submit Appeal</a>
+		</div>
+	</div>
+{:else}
 
 <div class="login-container">
 	<div class="login-box">
@@ -614,4 +625,21 @@
 			font-size: 0.85rem;
 		}
 	}
+
+	.appeal-box {
+		text-align: center;
+	}
+
+	.appeal-link {
+		display: inline-block;
+		margin-top: 0.75rem;
+		padding: 0.7rem 1rem;
+		border-radius: 8px;
+		background: #ff6b6b;
+		color: #fff;
+		text-decoration: none;
+		font-weight: 700;
+	}
 </style>
+
+{/if}

--- a/frontend/src/lib/socket-manager.ts
+++ b/frontend/src/lib/socket-manager.ts
@@ -117,6 +117,7 @@ export const channelOldestMessageId = writable<Record<string, string | null>>({}
 
 // Connection state for UI feedback
 export const connectionState = writable<ConnectionState>('disconnected');
+export const appealRequired = writable(false);
 
 // ============================================================================
 // SOCKET MANAGER CLASS - Singleton with State Machine
@@ -503,6 +504,27 @@ class SocketManager {
 			sock.emit('join', this.username);
 		});
 
+		sock.on('force-logout', () => {
+			console.warn('[SocketManager] Force logout received');
+			appealRequired.set(false);
+			authStore.clearAppealRequired();
+			this.safeLocalStorageRemove('appealRequired');
+			this.safeLocalStorageRemove('username');
+			this.safeLocalStorageRemove('sessionId');
+			this.safeLocalStorageRemove('authToken');
+			this.safeLocalStorageRemove('dbUserId');
+			authStore.setAuthError('Session terminated. Please log in again.', 'session_expired');
+			this.disconnect();
+		});
+
+		sock.on('appeal_required', () => {
+			console.warn('[SocketManager] Appeal required received');
+			appealRequired.set(true);
+			authStore.setAppealRequired();
+			this.safeLocalStorageSet('appealRequired', 'true');
+			this.disconnect();
+		});
+
 		sock.on('init', (data: {
 			channels: Channel[];
 			users: User[];
@@ -512,6 +534,9 @@ class SocketManager {
 			sessionId?: string;
 		}) => {
 			console.log('[SocketManager] Init received');
+			appealRequired.set(false);
+			authStore.clearAppealRequired();
+			this.safeLocalStorageRemove('appealRequired');
 
 			// Save session ID
 			if (data.sessionId) {
@@ -1062,6 +1087,17 @@ class SocketManager {
 
 	private classifyError(msg: string): { fatal: boolean; errorType: string; userMessage: string } {
 		const msgLower = msg.toLowerCase();
+
+		if (msgLower.includes('appeal_required')) {
+			appealRequired.set(true);
+			authStore.setAppealRequired();
+			this.safeLocalStorageSet('appealRequired', 'true');
+			return {
+				fatal: true,
+				errorType: 'appeal_required',
+				userMessage: 'Appeal required before account access can continue.'
+			};
+		}
 
 		// Auth errors - fatal, don't retry
 		if (msgLower.includes('session expired') || msgLower.includes('invalid token')) {

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -41,6 +41,7 @@ export {
 	dmPanelSignal,
 	emojis,
 	connectionState,
+	appealRequired,
 
 	// Pagination stores (client-side)
 	channelLoadedArchives,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -20,6 +20,13 @@
 	let cleanupAutoSave: (() => void) | null = null;
 
 	onMount(async () => {
+
+		const appealRequired = localStorage.getItem('appealRequired') === 'true';
+		if (appealRequired && window.location.pathname !== '/') {
+			window.location.href = '/';
+			return;
+		}
+
 		// Register service worker for PWA support
 		if ('serviceWorker' in navigator) {
 			navigator.serviceWorker.register('/sw.js').then((registration) => {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { onDestroy, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
-	import { initSocket, disconnect, dmPanelSignal } from '$lib/socket';
+	import { initSocket, disconnect, dmPanelSignal, appealRequired } from '$lib/socket';
 	import { requestNotificationPermission } from '$lib/notifications';
 	import Login from '$lib/components/Login.svelte';
 	import MainLayout from '$lib/components/MainLayout.svelte';
 	import type { PageData } from './$types';
 	import { layoutStore } from '$lib/layoutStore';
 	import { initE2E, clearE2EState } from '$lib/e2eManager';
+	import { authStore } from '$lib/authStore';
 
 	// Theme system
 	import { initializeTheme, watchThemeChanges, syncThemeToLocalStorage } from '$lib/theme/initTheme';
@@ -17,58 +18,28 @@
 	let loggedIn = typeof window !== 'undefined' && !!localStorage.getItem('username');
 	let isInitialLoad = true;
 	let showLoadingScreen = true;
+	let isAppealRequired = false;
 
 	let unsubscribeThemeWatcher: (() => void) | null = null;
 	let unsubscribeLocalStorageSync: (() => void) | null = null;
 
 	// --- Lifecycle ---
-	onMount(async () => {
+	onMount(() => {
 		showLoadingScreen = false;
 		isInitialLoad = false;
+		isAppealRequired = localStorage.getItem('appealRequired') === 'true';
 
-		const notificationsEnabled = localStorage.getItem('notificationsEnabled') !== 'false';
-		if (notificationsEnabled) await requestNotificationPermission();
-
-		layoutStore.subscribe(state => {
-			if (state.isMobile) {
-				layoutStore.resetPanelsOnDesktop();
-			}
+		const unsubscribeAppeal = appealRequired.subscribe((required) => {
+			isAppealRequired = required || localStorage.getItem('appealRequired') === 'true';
+			if (required) loggedIn = false;
 		});
 
-		const savedUsername = localStorage.getItem('username');
-		const savedToken = localStorage.getItem('authToken');
-		if (savedUsername) {
-			// Initialize E2E encryption if registered user (before socket, to validate session)
-			if (savedToken) {
-				const dbUserId = localStorage.getItem('dbUserId');
-				if (dbUserId) {
-					try {
-						await initE2E(parseInt(dbUserId, 10), savedToken, false);
-					} catch (err) {
-						console.error('[App] Cached session invalid, clearing login:', err);
-						// User no longer exists or session is invalid - force logout
-						localStorage.removeItem('username');
-						localStorage.removeItem('authToken');
-						localStorage.removeItem('dbUserId');
-						localStorage.removeItem('sessionId');
-						loggedIn = false;
-						return; // Skip socket init
-					}
-				}
+		const unsubscribeAuth = authStore.subscribe((state) => {
+			if (state.error?.type === 'session_expired' || state.error?.type === 'invalid_token' || state.appealRequired) {
+				loggedIn = false;
 			}
-
-			initSocket(savedUsername, savedToken || undefined);
-			loggedIn = true;
-		}
-
-		const isRegistered = !!savedToken;
-		await initializeTheme(isRegistered);
-
-		unsubscribeThemeWatcher = watchThemeChanges();
-
-		if (!isRegistered) {
-			unsubscribeLocalStorageSync = syncThemeToLocalStorage();
-		}
+			if (state.appealRequired) isAppealRequired = true;
+		});
 
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.ctrlKey && e.shiftKey && e.key === '1') {
@@ -81,11 +52,51 @@
 			}
 		};
 		window.addEventListener('keydown', handleKeyDown);
-		
+
+		void (async () => {
+			const notificationsEnabled = localStorage.getItem('notificationsEnabled') !== 'false';
+			if (notificationsEnabled) await requestNotificationPermission();
+
+			layoutStore.subscribe(state => {
+				if (state.isMobile) layoutStore.resetPanelsOnDesktop();
+			});
+
+			const savedUsername = localStorage.getItem('username');
+			const savedToken = localStorage.getItem('authToken');
+			if (savedUsername) {
+				if (savedToken) {
+					const dbUserId = localStorage.getItem('dbUserId');
+					if (dbUserId) {
+						try {
+							await initE2E(parseInt(dbUserId, 10), savedToken, false);
+						} catch (err) {
+							console.error('[App] Cached session invalid, clearing login:', err);
+							localStorage.removeItem('username');
+							localStorage.removeItem('authToken');
+							localStorage.removeItem('dbUserId');
+							localStorage.removeItem('sessionId');
+							loggedIn = false;
+							return;
+						}
+					}
+				}
+
+				initSocket(savedUsername, savedToken || undefined);
+				loggedIn = true;
+			}
+
+			const isRegistered = !!savedToken;
+			await initializeTheme(isRegistered);
+			unsubscribeThemeWatcher = watchThemeChanges();
+			if (!isRegistered) unsubscribeLocalStorageSync = syncThemeToLocalStorage();
+		})();
+
 		return () => {
 			window.removeEventListener('keydown', handleKeyDown);
 			unsubscribeThemeWatcher?.();
 			unsubscribeLocalStorageSync?.();
+			unsubscribeAppeal();
+			unsubscribeAuth();
 		};
 	});
 	
@@ -101,6 +112,7 @@
 
 	async function handleLogin(event: CustomEvent<{ username: string; token?: string; authMethod: 'guest' | 'registered' }>) {
 		const { username, token, authMethod } = event.detail;
+		if (isAppealRequired) return;
 		localStorage.setItem('username', username);
 
 		if (token) {
@@ -128,10 +140,14 @@
 		disconnect();
 		clearE2EState();
 		loggedIn = false;
+		isAppealRequired = false;
+		authStore.clearAppealRequired();
+		appealRequired.set(false);
 		try {
 			localStorage.removeItem('username');
 			localStorage.removeItem('sessionId');
 			localStorage.removeItem('authToken');
+			localStorage.removeItem('appealRequired');
 		} catch (e) {
 			console.error('Failed to clear localStorage:', e);
 		}
@@ -142,12 +158,18 @@
 	<div class="loading-screen" transition:fade={{ duration: 400 }}></div>
 {/if}
 
-{#if !loggedIn}
+{#if isAppealRequired}
+	<div class="appeal-gate" transition:fade={{ duration: 300 }}>
+		<h1>Access Restricted</h1>
+		<p>Your account requires an appeal review before chat access can continue.</p>
+		<a class="appeal-cta" href="mailto:appeals@wabi.chat?subject=Appeal%20Request">Submit Appeal</a>
+	</div>
+{:else if !loggedIn}
 	{#if isInitialLoad}
-		<Login on:login={handleLogin} />
+		<Login on:login={handleLogin} appealRequired={isAppealRequired} />
 	{:else}
 		<div transition:fade={{ duration: 300 }}>
-			<Login on:login={handleLogin} />
+			<Login on:login={handleLogin} appealRequired={isAppealRequired} />
 		</div>
 	{/if}
 {:else}
@@ -161,6 +183,30 @@
 {/if}
 
 <style>
+	.appeal-gate {
+		position: fixed;
+		inset: 0;
+		display: grid;
+		place-content: center;
+		gap: 0.75rem;
+		text-align: center;
+		padding: 2rem;
+		background: var(--gradient-loading-dark);
+		color: #fff;
+		z-index: 10001;
+	}
+
+	.appeal-cta {
+		display: inline-block;
+		margin-top: 0.5rem;
+		padding: 0.7rem 1rem;
+		border-radius: 8px;
+		background: #ff6b6b;
+		color: #fff;
+		text-decoration: none;
+		font-weight: 700;
+	}
+
 	.loading-screen {
 		position: fixed;
 		inset: 0;


### PR DESCRIPTION
### Motivation
- Add minimal sanction tracking so repeated attempts to evade account restrictions are detected and handled automatically.
- Immediately invalidate sessions on first evasion and present a hard appeal-required gate on repeated evasion attempts to prevent account access bypass.

### Description
- DB: added `user_sanctions` table and migration + index to persist `is_sanctioned`, `evasion_count`, `appeal_required`, and `updated_at` values.
- Backend: introduced `userSanctionRepository` and `processSanctionEvasion()` and wired checks into Socket.IO auth middleware plus `join`/`rejoin` flows to emit `force-logout` (first evasion, session invalidated) or `appeal_required` (second+ evasion) and stop bootstrap.
- Frontend: extended `authStore` with `appealRequired` handling, exported a new `appealRequired` socket store, and updated `socket-manager` to handle `force-logout` (clear auth + disconnect) and `appeal_required` (set persistent appeal gate and disconnect); re-exported the new store from legacy `socket` entrypoint.
- UI/route protection: added a blocking appeal gate UI in `Login.svelte`, prevented login/route entry while appeal-required is active in `+page.svelte`, and added a layout redirect to `/` when a persisted appeal gate is present in `+layout.svelte`.

### Testing
- Built backend with `cd backend && bun run build`, which completed successfully. (✅)
- Built frontend with `cd frontend && bun run build`, which completed successfully and produced the production bundles. (✅)
- Ran static checks with `cd frontend && bun run check`, which failed due to many pre-existing unrelated TypeScript/Svelte diagnostics in the repository (this is an existing repo issue, not caused by the sanction changes). (⚠️)
- Launched the dev frontend and captured a browser screenshot of the appeal gate via Playwright to validate the gate UI appears when `appealRequired` is set in localStorage. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e04469f8832a9d5fe605b431c092)