### PR TITLE
Add blocked username management and enforcement

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -3,8 +3,10 @@ import { userRepository } from '../db/repositories/userRepository.js';
 import { sessionRepository } from '../db/repositories/sessionRepository.js';
 import { settingsRepository } from '../db/repositories/settingsRepository.js';
 import { encryptionKeyRepository } from '../db/repositories/encryptionKeyRepository.js';
+import { blockedUsernameRepository, normalizeUsernameForBlocklist } from '../db/repositories/blockedUsernameRepository.js';
 import { hashPassword, verifyPassword } from '../auth/passwordHash.js';
 import { generateToken, verifyToken } from '../auth/jwt.js';
+import { hasRequiredRole } from '../auth/roleMiddleware.js';
 
 // Get authenticated user ID from request
 function getAuthenticatedUserId(req: IncomingMessage): number | null {
@@ -71,6 +73,18 @@ function validateInput(username: string, password: string): { valid: boolean; er
 	return { valid: true };
 }
 
+function validateUsernameOnly(username: string): { valid: boolean; error?: string } {
+	if (!username || username.trim().length < 2) {
+		return { valid: false, error: 'Username must be at least 2 characters' };
+	}
+
+	if (username.length > 32) {
+		return { valid: false, error: 'Username must be less than 32 characters' };
+	}
+
+	return { valid: true };
+}
+
 // Parse JSON body
 function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
 	return new Promise((resolve, reject) => {
@@ -107,6 +121,29 @@ function generateColor(): string {
 	return colors[Math.floor(Math.random() * colors.length)];
 }
 
+function respondBlockedUsername(
+	res: ServerResponse,
+	blockedReason?: string | null,
+	normalizedName?: string
+): void {
+	res.writeHead(403, { 'Content-Type': 'application/json' });
+	res.end(
+		JSON.stringify({
+			error: 'username_blocked',
+			code: 'username_blocked',
+			reason: blockedReason || null,
+			normalizedName: normalizedName || null
+		})
+	);
+}
+
+function isAdminUser(req: IncomingMessage): number | null {
+	const userId = getAuthenticatedUserId(req);
+	if (!userId) return null;
+	if (hasRequiredRole(userId, ['admin', 'owner'])) return userId;
+	return null;
+}
+
 export async function handleRegister(req: IncomingMessage, res: ServerResponse): Promise<void> {
 	try {
 		const clientIp = req.socket.remoteAddress || 'unknown';
@@ -138,6 +175,12 @@ export async function handleRegister(req: IncomingMessage, res: ServerResponse):
 		if (!/^[a-z][a-z0-9_]{1,31}$/.test(handle)) {
 			res.writeHead(400, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ error: 'Handle must start with a letter, be 2-32 chars, and contain only lowercase letters, numbers, and underscores' }));
+			return;
+		}
+
+		const blockedCheck = blockedUsernameRepository.isBlocked(username);
+		if (blockedCheck.blocked) {
+			respondBlockedUsername(res, blockedCheck.entry?.reason, blockedCheck.normalizedName);
 			return;
 		}
 
@@ -341,6 +384,12 @@ export async function handleUpgrade(req: IncomingMessage, res: ServerResponse): 
 		}
 
 		// Check if username already registered
+		const blockedCheck = blockedUsernameRepository.isBlocked(tempSession.username);
+		if (blockedCheck.blocked) {
+			respondBlockedUsername(res, blockedCheck.entry?.reason, blockedCheck.normalizedName);
+			return;
+		}
+
 		if (userRepository.findByUsername(tempSession.username)) {
 			res.writeHead(409, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ error: 'Username already taken' }));
@@ -413,6 +462,149 @@ export async function handleUpgrade(req: IncomingMessage, res: ServerResponse): 
 		console.error('[Auth] Upgrade error:', error);
 		res.writeHead(500, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({ error: 'Upgrade failed' }));
+	}
+}
+
+export async function handleRename(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const userId = getAuthenticatedUserId(req);
+		if (!userId) {
+			res.writeHead(401, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Not authenticated' }));
+			return;
+		}
+
+		const body = await parseBody(req);
+		const newUsername = (body.username || '').trim();
+		const handleInput = (body.handle || '').trim();
+
+		const usernameValidation = validateUsernameOnly(newUsername);
+		if (!usernameValidation.valid) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: usernameValidation.error }));
+			return;
+		}
+
+		const blockedCheck = blockedUsernameRepository.isBlocked(newUsername);
+		if (blockedCheck.blocked) {
+			respondBlockedUsername(res, blockedCheck.entry?.reason, blockedCheck.normalizedName);
+			return;
+		}
+
+		const existing = userRepository.findByUsername(newUsername);
+		if (existing && existing.user_id !== userId) {
+			res.writeHead(409, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Username already taken' }));
+			return;
+		}
+
+		const normalizedHandle = handleInput
+			? handleInput.replace(/^@/, '').toLowerCase()
+			: newUsername.replace(/\s+/g, '').toLowerCase();
+
+		if (!/^[a-z][a-z0-9_]{1,31}$/.test(normalizedHandle)) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Handle must start with a letter, be 2-32 chars, and contain only lowercase letters, numbers, and underscores' }));
+			return;
+		}
+
+		const existingHandle = userRepository.findByHandle(normalizedHandle);
+		if (existingHandle && existingHandle.user_id !== userId) {
+			res.writeHead(409, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Handle already taken' }));
+			return;
+		}
+
+		userRepository.rename(userId, newUsername, normalizedHandle);
+		sessionRepository.renameByUserId(userId, newUsername);
+
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ success: true, username: newUsername, handle: normalizedHandle }));
+	} catch (error) {
+		console.error('[Auth] Rename error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to rename user' }));
+	}
+}
+
+export async function handleGetBlockedUsernames(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		if (!isAdminUser(req)) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Admin access required' }));
+			return;
+		}
+
+		const blocked = blockedUsernameRepository.listActive();
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ blocked }));
+	} catch (error) {
+		console.error('[Auth] Get blocked usernames error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to fetch blocked usernames' }));
+	}
+}
+
+export async function handleAddBlockedUsername(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const adminUserId = isAdminUser(req);
+		if (!adminUserId) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Admin access required' }));
+			return;
+		}
+
+		const body = await parseBody(req);
+		const name = (body.name || '').trim();
+		const reason = (body.reason || '').trim();
+
+		if (!name) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'name is required' }));
+			return;
+		}
+
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		if (!normalizedName) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'name does not produce a valid normalized key' }));
+			return;
+		}
+
+		const created = blockedUsernameRepository.upsert(name, reason || undefined, adminUserId);
+		res.writeHead(201, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ blocked: created }));
+	} catch (error) {
+		console.error('[Auth] Add blocked username error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to add blocked username' }));
+	}
+}
+
+export async function handleRemoveBlockedUsername(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		if (!isAdminUser(req)) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Admin access required' }));
+			return;
+		}
+
+		const body = await parseBody(req);
+		const name = (body.name || '').trim();
+
+		if (!name) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'name is required' }));
+			return;
+		}
+
+		blockedUsernameRepository.deactivateByName(name);
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ success: true }));
+	} catch (error) {
+		console.error('[Auth] Remove blocked username error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to remove blocked username' }));
 	}
 }
 

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -145,6 +145,25 @@ function runMigrations() {
 		// Columns may already exist
 	}
 
+
+	// Migration: Add blocked_usernames table
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS blocked_usernames (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				normalized_name TEXT NOT NULL UNIQUE,
+				reason TEXT,
+				created_at INTEGER NOT NULL,
+				created_by INTEGER,
+				active INTEGER NOT NULL DEFAULT 1,
+				FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+			)
+		`);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_blocked_usernames_active ON blocked_usernames(active)');
+	} catch (e) {
+		console.error('[Database] Migration error adding blocked_usernames table:', e);
+	}
+
 	// Migration: Add encryption columns to messages table
 	try {
 		const cols = db.pragma('table_info(messages)') as { name: string }[];

--- a/backend/src/db/repositories/blockedUsernameRepository.ts
+++ b/backend/src/db/repositories/blockedUsernameRepository.ts
@@ -1,0 +1,109 @@
+import db from '../database.js';
+
+export interface BlockedUsername {
+	id?: number;
+	normalized_name: string;
+	reason?: string | null;
+	created_at: number;
+	created_by?: number | null;
+	active: number;
+}
+
+export function normalizeUsernameForBlocklist(value: string): string {
+	return value
+		.normalize('NFKC')
+		.trim()
+		.toLowerCase()
+		.replace(/^@+/, '')
+		.replace(/\s+/g, '')
+		.replace(/[^a-z0-9_]/g, '');
+}
+
+export class BlockedUsernameRepository {
+	create(name: string, reason?: string, createdBy?: number): BlockedUsername {
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		const now = Date.now();
+		const stmt = db.prepare(`
+			INSERT INTO blocked_usernames (normalized_name, reason, created_at, created_by, active)
+			VALUES (?, ?, ?, ?, 1)
+		`);
+		const info = stmt.run(normalizedName, reason || null, now, createdBy || null);
+		return {
+			id: info.lastInsertRowid as number,
+			normalized_name: normalizedName,
+			reason: reason || null,
+			created_at: now,
+			created_by: createdBy || null,
+			active: 1
+		};
+	}
+
+	upsert(name: string, reason?: string, createdBy?: number): BlockedUsername {
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		const now = Date.now();
+		const stmt = db.prepare(`
+			INSERT INTO blocked_usernames (normalized_name, reason, created_at, created_by, active)
+			VALUES (?, ?, ?, ?, 1)
+			ON CONFLICT(normalized_name)
+			DO UPDATE SET reason = excluded.reason, created_by = excluded.created_by, active = 1
+		`);
+		stmt.run(normalizedName, reason || null, now, createdBy || null);
+		const row = this.findByNormalizedName(normalizedName);
+		if (!row) {
+			throw new Error('Failed to upsert blocked username');
+		}
+		return row;
+	}
+
+	findByNormalizedName(normalizedName: string): BlockedUsername | null {
+		const stmt = db.prepare('SELECT * FROM blocked_usernames WHERE normalized_name = ?');
+		return (stmt.get(normalizedName) as BlockedUsername) || null;
+	}
+
+	listActive(): BlockedUsername[] {
+		const stmt = db.prepare('SELECT * FROM blocked_usernames WHERE active = 1 ORDER BY created_at DESC');
+		return stmt.all() as BlockedUsername[];
+	}
+
+	update(id: number, updates: { reason?: string; active?: number }): void {
+		const fields: string[] = [];
+		const values: Array<string | number | null> = [];
+
+		if (updates.reason !== undefined) {
+			fields.push('reason = ?');
+			values.push(updates.reason || null);
+		}
+		if (updates.active !== undefined) {
+			fields.push('active = ?');
+			values.push(updates.active);
+		}
+		if (fields.length === 0) return;
+
+		const stmt = db.prepare(`UPDATE blocked_usernames SET ${fields.join(', ')} WHERE id = ?`);
+		stmt.run(...values, id);
+	}
+
+	deactivateByName(name: string): void {
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		const stmt = db.prepare('UPDATE blocked_usernames SET active = 0 WHERE normalized_name = ?');
+		stmt.run(normalizedName);
+	}
+
+	deleteByName(name: string): void {
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		const stmt = db.prepare('DELETE FROM blocked_usernames WHERE normalized_name = ?');
+		stmt.run(normalizedName);
+	}
+
+	isBlocked(name: string): { blocked: boolean; entry: BlockedUsername | null; normalizedName: string } {
+		const normalizedName = normalizeUsernameForBlocklist(name);
+		if (!normalizedName) {
+			return { blocked: false, entry: null, normalizedName };
+		}
+		const stmt = db.prepare('SELECT * FROM blocked_usernames WHERE normalized_name = ? AND active = 1');
+		const entry = (stmt.get(normalizedName) as BlockedUsername) || null;
+		return { blocked: !!entry, entry, normalizedName };
+	}
+}
+
+export const blockedUsernameRepository = new BlockedUsernameRepository();

--- a/backend/src/db/repositories/sessionRepository.ts
+++ b/backend/src/db/repositories/sessionRepository.ts
@@ -61,6 +61,12 @@ export class SessionRepository {
 		stmt.run(...values, sessionId);
 	}
 
+
+	renameByUserId(userId: number, username: string): void {
+		const stmt = db.prepare('UPDATE sessions SET username = ? WHERE user_id = ?');
+		stmt.run(username, userId);
+	}
+
 	// Delete session
 	delete(sessionId: string): void {
 		const stmt = db.prepare('DELETE FROM sessions WHERE session_id = ?');

--- a/backend/src/db/repositories/userRepository.ts
+++ b/backend/src/db/repositories/userRepository.ts
@@ -110,6 +110,13 @@ export class UserRepository {
 		stmt.run(...values, userId);
 	}
 
+
+	// Rename user and handle
+	rename(userId: number, username: string, handle: string): void {
+		const stmt = db.prepare('UPDATE users SET username = ?, handle = ? WHERE user_id = ?');
+		stmt.run(username, handle, userId);
+	}
+
 	// Delete user
 	delete(userId: number): void {
 		const stmt = db.prepare('DELETE FROM users WHERE user_id = ?');

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -125,6 +125,18 @@ CREATE TABLE IF NOT EXISTS guest_codes (
   FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
 );
 
+
+-- Blocked usernames (for registration and rename checks)
+CREATE TABLE IF NOT EXISTS blocked_usernames (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  normalized_name TEXT NOT NULL UNIQUE,
+  reason TEXT,
+  created_at INTEGER NOT NULL,
+  created_by INTEGER,
+  active INTEGER NOT NULL DEFAULT 1,
+  FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+);
+
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_offline_messages_to_user ON offline_messages(to_user_id, delivered);
@@ -134,6 +146,7 @@ CREATE INDEX IF NOT EXISTS idx_users_handle ON users(handle COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_user_roles_user ON user_roles(user_id);
 CREATE INDEX IF NOT EXISTS idx_resource_visibility_resource ON resource_visibility(resource_id);
 CREATE INDEX IF NOT EXISTS idx_guest_codes_active ON guest_codes(is_active);
+CREATE INDEX IF NOT EXISTS idx_blocked_usernames_active ON blocked_usernames(active);
 
 -- Initial guest code
 INSERT OR IGNORE INTO guest_codes (code, description, is_active)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,7 +14,19 @@ import { settingsRepository } from "./db/repositories/settingsRepository.js";
 import { themeRepository } from "./db/repositories/themeRepository.js";
 import { guestCodeRepository } from "./db/repositories/guestCodeRepository.js";
 import { verifyToken } from "./auth/jwt.js";
-import { handleRegister, handleLogin, handleUpgrade, handleGetUserSettings, handleSaveUserSettings, handleGetPublicKey, handleStoreEncryptionKeys } from "./api/authRoutes.js";
+import {
+  handleRegister,
+  handleLogin,
+  handleUpgrade,
+  handleGetUserSettings,
+  handleSaveUserSettings,
+  handleGetPublicKey,
+  handleStoreEncryptionKeys,
+  handleRename,
+  handleGetBlockedUsernames,
+  handleAddBlockedUsername,
+  handleRemoveBlockedUsername
+} from "./api/authRoutes.js";
 import { handleGetThemePreferences, handleSaveThemePreferences, handleResetThemePreferences } from "./api/themeRoutes.js";
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
 import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
@@ -930,6 +942,26 @@ server.on('request', async (req, res) => {
 
   if (url.pathname === "/api/auth/upgrade" && req.method === "POST") {
     await handleUpgrade(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/auth/rename" && req.method === "POST") {
+    await handleRename(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/admin/blocked-usernames" && req.method === "GET") {
+    await handleGetBlockedUsernames(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/admin/blocked-usernames" && req.method === "POST") {
+    await handleAddBlockedUsername(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/admin/blocked-usernames" && req.method === "DELETE") {
+    await handleRemoveBlockedUsername(req, res);
     return;
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,6 +28,10 @@ export async function register(username: string, password: string, handle?: stri
 
 		if (!res.ok) {
 			const error = await res.json();
+			if (error?.code === 'username_blocked' || error?.error === 'username_blocked') {
+				const reason = error?.reason ? ` (${error.reason})` : '';
+				throw new Error(`Username is blocked${reason}`);
+			}
 			throw new Error(error.error || 'Registration failed');
 		}
 

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -70,6 +70,24 @@
 	let bulkEmojiFiles: { file: File; name: string; preview: string }[] = [];
 	let uploadingBulk = false;
 
+
+	// Blocked username admin state
+	let blockedNameInput = '';
+	let blockedReasonInput = '';
+	let blockedNamePreview = '';
+	let blockedNames: Array<{ id?: number; normalized_name: string; reason?: string | null; created_at: number; created_by?: number | null; active: number }> = [];
+	let loadingBlockedNames = false;
+	let savingBlockedName = false;
+	let blockedNamesError = '';
+	let isAdminUser = false;
+	let hasLoadedBlockedNames = false;
+	$: isAdminUser = !!($currentUser?.roles?.includes('admin') || $currentUser?.roles?.includes('owner'));
+	$: blockedNamePreview = normalizeBlockedName(blockedNameInput);
+	$: if (isAdminUser && !hasLoadedBlockedNames) {
+		hasLoadedBlockedNames = true;
+		void loadBlockedNames();
+	}
+
 	// Load settings from localStorage and enforce server policy
 	onMount(() => {
 		soundEnabled = localStorage.getItem('soundEnabled') !== 'false';
@@ -435,6 +453,85 @@
 		bulkEmojiFiles = bulkEmojiFiles.filter((_, i) => i !== index);
 	}
 
+
+	function normalizeBlockedName(value: string): string {
+		return value
+			.normalize('NFKC')
+			.trim()
+			.toLowerCase()
+			.replace(/^@+/, '')
+			.replace(/\s+/g, '')
+			.replace(/[^a-z0-9_]/g, '');
+	}
+
+	async function loadBlockedNames() {
+		if (!isAdminUser) return;
+		loadingBlockedNames = true;
+		blockedNamesError = '';
+		try {
+			const token = localStorage.getItem('authToken');
+			if (!token) throw new Error('Missing auth token');
+			const response = await fetch(`${getServerUrl()}/api/admin/blocked-usernames`, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${token}` }
+			});
+			const result = await response.json();
+			if (!response.ok) throw new Error(result.error || 'Failed to load blocked names');
+			blockedNames = result.blocked || [];
+		} catch (error) {
+			blockedNamesError = error instanceof Error ? error.message : 'Failed to load blocked names';
+		} finally {
+			loadingBlockedNames = false;
+		}
+	}
+
+	async function addBlockedName() {
+		if (!blockedNameInput.trim()) return;
+		savingBlockedName = true;
+		blockedNamesError = '';
+		try {
+			const token = localStorage.getItem('authToken');
+			if (!token) throw new Error('Missing auth token');
+			const response = await fetch(`${getServerUrl()}/api/admin/blocked-usernames`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ name: blockedNameInput, reason: blockedReasonInput })
+			});
+			const result = await response.json();
+			if (!response.ok) throw new Error(result.error || 'Failed to add blocked name');
+			blockedNameInput = '';
+			blockedReasonInput = '';
+			await loadBlockedNames();
+		} catch (error) {
+			blockedNamesError = error instanceof Error ? error.message : 'Failed to add blocked name';
+		} finally {
+			savingBlockedName = false;
+		}
+	}
+
+	async function removeBlockedName(name: string) {
+		try {
+			const token = localStorage.getItem('authToken');
+			if (!token) throw new Error('Missing auth token');
+			const response = await fetch(`${getServerUrl()}/api/admin/blocked-usernames`, {
+				method: 'DELETE',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ name })
+			});
+			const result = await response.json();
+			if (!response.ok) throw new Error(result.error || 'Failed to remove blocked name');
+			await loadBlockedNames();
+		} catch (error) {
+			blockedNamesError = error instanceof Error ? error.message : 'Failed to remove blocked name';
+		}
+	}
+
 	async function confirmClearServer() {
 
 		try {
@@ -781,6 +878,47 @@
 						<UniformFontMode />
 					</div>
 				</div>
+
+
+				{#if isAdminUser}
+					<div class="settings-section">
+						<h3>🚫 Blocked Usernames</h3>
+						<div class="setting-item-full">
+							<div class="setting-info">
+								<span class="setting-label">Add blocked name</span>
+								<span class="setting-description">Usernames normalize to lowercase letters/numbers/underscore with spaces removed.</span>
+							</div>
+							<input type="text" bind:value={blockedNameInput} placeholder="e.g. Admin Team" class="emoji-name-input" />
+							<input type="text" bind:value={blockedReasonInput} placeholder="Reason (optional)" class="emoji-name-input" />
+							<p class="emoji-hint">Stored key preview: <code>{blockedNamePreview || '—'}</code></p>
+							<button class="action-btn" on:click={addBlockedName} disabled={savingBlockedName || !blockedNamePreview}>
+								{savingBlockedName ? 'Saving…' : 'Add blocked name'}
+							</button>
+							{#if blockedNamesError}
+								<p class="runtime-note">{blockedNamesError}</p>
+							{/if}
+						</div>
+						<div class="emoji-list">
+							<h4>Active blocked names ({blockedNames.length})</h4>
+							{#if loadingBlockedNames}
+								<p class="emoji-hint">Loading…</p>
+							{:else if blockedNames.length === 0}
+								<p class="emoji-hint">No blocked usernames configured.</p>
+							{:else}
+								{#each blockedNames as item (item.normalized_name)}
+									<div class="setting-item">
+										<div class="setting-info">
+											<span class="setting-label"><code>{item.normalized_name}</code></span>
+											<span class="setting-description">{item.reason || 'No reason provided'}</span>
+										</div>
+										<button class="action-btn danger" on:click={() => removeBlockedName(item.normalized_name)}>Remove</button>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					</div>
+				{/if}
+
 
 				<!-- Server Management -->
 				<div class="settings-section">


### PR DESCRIPTION
### Motivation
- Prevent abusive or reserved names from being registered or chosen by users by introducing a normalized blocklist and admin management UI.
- Ensure server- and client-side normalization is consistent so admins see the exact stored match key before saving.

### Description
- Added a new `blocked_usernames` table to `backend/src/db/schema.sql` and a migration in `backend/src/db/database.ts` with an index on `active` to support enforcement and existing-install migrations.
- Implemented `backend/src/db/repositories/blockedUsernameRepository.ts` with `normalizeUsernameForBlocklist`, `create`, `upsert`, `listActive`, `update`, `deactivateByName`, `deleteByName`, and `isBlocked` helper methods for CRUD and checks.
- Enforced blocklist checks in authentication flows by updating `backend/src/api/authRoutes.ts` to return a structured blocked error (`error: 'username_blocked', code: 'username_blocked'`) during `register`, `upgrade` (temp->registered), and new `rename` flow, and added admin endpoints `GET/POST/DELETE /api/admin/blocked-usernames` for management.
- Wired routes in `backend/src/server.ts` and added repository support for renaming (`userRepository.rename` and `sessionRepository.renameByUserId`) so renames update both users and sessions.
- Frontend changes in `frontend/src/lib/api.ts` now recognize the structured `username_blocked` response, and `frontend/src/lib/components/Settings.svelte` includes an admin UI to add/remove/list blocked names plus a live client-side normalization preview of the stored match key.

### Testing
- Built the backend bundle with `npm --prefix backend run build` and the command completed successfully (`esbuild` output produced `dist/server.js`).
- Built the frontend with `npm --prefix frontend run build` and the Vite build completed successfully (production assets emitted).
- Ran `npm --prefix frontend run check` which reported existing TypeScript/Svelte diagnostics in the repository unrelated to this change; the check failures are pre-existing and not introduced by this PR while the frontend build still succeeds.
- Performed a quick UI smoke test by launching the frontend dev server and capturing a settings screenshot to verify the admin blocked-names section renders (artifact: `artifacts/settings-blocked-usernames.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e04c2960832a8aba7995ed39c568)