### PR TITLE
Add raid mode: admin toggle, signup blocking, stricter messaging limits and expiry

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -119,6 +119,12 @@ export async function handleRegister(req: IncomingMessage, res: ServerResponse):
 			return;
 		}
 
+		if (settingsRepository.isRaidModeActive()) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Registrations are temporarily disabled while raid mode is active.' }));
+			return;
+		}
+
 		const body = await parseBody(req);
 		const { username, password, handle: rawHandle } = body;
 
@@ -315,6 +321,12 @@ export async function handleLogin(req: IncomingMessage, res: ServerResponse): Pr
 
 export async function handleUpgrade(req: IncomingMessage, res: ServerResponse): Promise<void> {
 	try {
+		if (settingsRepository.isRaidModeActive()) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Account upgrades are temporarily disabled while raid mode is active.' }));
+			return;
+		}
+
 		const body = await parseBody(req);
 		const { sessionId, password } = body;
 

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -156,6 +156,28 @@ function runMigrations() {
 	} catch (e) {
 		// Columns may already exist
 	}
+
+	// Migration: Ensure app settings table and raid-mode columns exist
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS app_settings (
+				id INTEGER PRIMARY KEY CHECK (id = 1),
+				raid_mode_enabled INTEGER DEFAULT 0,
+				raid_mode_expires_at INTEGER
+			)
+		`);
+		db.prepare('INSERT OR IGNORE INTO app_settings (id, raid_mode_enabled, raid_mode_expires_at) VALUES (1, 0, NULL)').run();
+		const appCols = db.pragma('table_info(app_settings)') as { name: string }[];
+		if (!appCols.some(c => c.name === 'raid_mode_enabled')) {
+			db.exec('ALTER TABLE app_settings ADD COLUMN raid_mode_enabled INTEGER DEFAULT 0');
+		}
+		if (!appCols.some(c => c.name === 'raid_mode_expires_at')) {
+			db.exec('ALTER TABLE app_settings ADD COLUMN raid_mode_expires_at INTEGER');
+		}
+	} catch (e) {
+		console.error('[Database] Migration error ensuring app_settings raid mode columns:', e);
+	}
+
 }
 
 function seedDefaultRoles() {

--- a/backend/src/db/repositories/settingsRepository.ts
+++ b/backend/src/db/repositories/settingsRepository.ts
@@ -7,7 +7,55 @@ export interface UserSettings {
 	business_private_mode?: number;
 }
 
+export interface AppSettings {
+	raid_mode_enabled: number;
+	raid_mode_expires_at: number | null;
+}
+
 export class SettingsRepository {
+	getAppSettings(): AppSettings {
+		const row = db
+			.prepare('SELECT raid_mode_enabled, raid_mode_expires_at FROM app_settings WHERE id = 1')
+			.get() as AppSettings | undefined;
+
+		if (!row) {
+			db.prepare('INSERT INTO app_settings (id, raid_mode_enabled, raid_mode_expires_at) VALUES (1, 0, NULL)').run();
+			return { raid_mode_enabled: 0, raid_mode_expires_at: null };
+		}
+
+		return row;
+	}
+
+	setAppSettings(settings: Partial<AppSettings>): AppSettings {
+		const fields = Object.keys(settings) as (keyof AppSettings)[];
+		if (fields.length === 0) return this.getAppSettings();
+
+		const setClause = fields.map((field) => `${field} = ?`).join(', ');
+		const values = fields.map((field) => settings[field]);
+
+		db.prepare(`UPDATE app_settings SET ${setClause} WHERE id = 1`).run(...values);
+		return this.getAppSettings();
+	}
+
+	isRaidModeActive(now = Date.now()): boolean {
+		const appSettings = this.getAppSettings();
+		if (appSettings.raid_mode_enabled !== 1) return false;
+		if (appSettings.raid_mode_expires_at && appSettings.raid_mode_expires_at <= now) {
+			this.setAppSettings({ raid_mode_enabled: 0, raid_mode_expires_at: null });
+			return false;
+		}
+		return true;
+	}
+
+	expireRaidModeIfNeeded(now = Date.now()): boolean {
+		const appSettings = this.getAppSettings();
+		if (appSettings.raid_mode_enabled === 1 && appSettings.raid_mode_expires_at && appSettings.raid_mode_expires_at <= now) {
+			this.setAppSettings({ raid_mode_enabled: 0, raid_mode_expires_at: null });
+			return true;
+		}
+		return false;
+	}
+
 	// Get settings for a user (create defaults if not exists)
 	get(userId: number): UserSettings {
 		let settings = this.findById(userId);

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -59,6 +59,16 @@ CREATE TABLE IF NOT EXISTS user_settings (
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
+-- App-wide settings
+CREATE TABLE IF NOT EXISTS app_settings (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  raid_mode_enabled INTEGER DEFAULT 0,
+  raid_mode_expires_at INTEGER
+);
+
+INSERT OR IGNORE INTO app_settings (id, raid_mode_enabled, raid_mode_expires_at)
+VALUES (1, 0, NULL);
+
 -- Theme preferences (appearance customization)
 CREATE TABLE IF NOT EXISTS theme_preferences (
   user_id INTEGER PRIMARY KEY,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -137,6 +137,48 @@ function generateSessionId(): string {
 
 const typingUsers = new Set<string>();
 
+const messageRateLimitMap = new Map<string, { count: number; resetTime: number }>();
+
+function checkMessageRateLimit(userKey: string, raidModeActive: boolean): boolean {
+  const now = Date.now();
+  const windowMs = 10 * 1000;
+  const maxMessages = raidModeActive ? 5 : 20;
+  const entry = messageRateLimitMap.get(userKey);
+
+  if (!entry || now > entry.resetTime) {
+    messageRateLimitMap.set(userKey, { count: 1, resetTime: now + windowMs });
+    return true;
+  }
+
+  if (entry.count >= maxMessages) {
+    return false;
+  }
+
+  entry.count += 1;
+  return true;
+}
+
+function isStaffRole(role?: string): boolean {
+  return !!role && ['owner', 'admin', 'mod'].includes(role);
+}
+
+function isAdminRole(role?: string): boolean {
+  return !!role && ['owner', 'admin'].includes(role);
+}
+
+function getRaidModeState() {
+  const expired = settingsRepository.expireRaidModeIfNeeded();
+  if (expired) {
+    console.log('[RaidMode] Auto-expired raid mode due to timeout');
+  }
+
+  const appSettings = settingsRepository.getAppSettings();
+  return {
+    raidModeEnabled: appSettings.raid_mode_enabled === 1,
+    raidModeExpiresAt: appSettings.raid_mode_expires_at
+  };
+}
+
 // Business workspace data - for collaborative business features
 interface BusinessData {
   workspaceId: string;
@@ -1083,6 +1125,80 @@ server.on('request', async (req, res) => {
     return;
   }
 
+
+  // Update raid mode (admin-only)
+  if (url.pathname === "/api/admin/raid-mode" && req.method === "POST") {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Unauthorized' }));
+      return;
+    }
+
+    const roleInfo = getUserRoleInfo(userId);
+    if (!isAdminRole(roleInfo.highestRole)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      try {
+        const parsed = JSON.parse(body || '{}');
+        const raidModeEnabled = !!parsed.raidModeEnabled;
+        const expiresAtRaw = parsed.raidModeExpiresAt;
+        const raidModeExpiresAt = typeof expiresAtRaw === 'number' && Number.isFinite(expiresAtRaw) ? expiresAtRaw : null;
+
+        const updated = settingsRepository.setAppSettings({
+          raid_mode_enabled: raidModeEnabled ? 1 : 0,
+          raid_mode_expires_at: raidModeEnabled ? raidModeExpiresAt : null
+        });
+
+        const payload = {
+          raidModeEnabled: updated.raid_mode_enabled === 1,
+          raidModeExpiresAt: updated.raid_mode_expires_at
+        };
+
+        emitRaidModeToStaffClients();
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ success: true, ...payload }));
+      } catch (error) {
+        console.error('Failed to update raid mode:', error);
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: 'Failed to update raid mode' }));
+      }
+    });
+    return;
+  }
+
+  // Read raid mode (admin/staff only)
+  if (url.pathname === "/api/admin/raid-mode" && req.method === "GET") {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Unauthorized' }));
+      return;
+    }
+
+    const roleInfo = getUserRoleInfo(userId);
+    if (!isStaffRole(roleInfo.highestRole)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+      return;
+    }
+
+    const payload = getRaidModeState();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
+    return;
+  }
+
   // Toggle business private mode
   if (url.pathname === "/api/user/business-private-mode" && req.method === "POST") {
     const userId = getAuthenticatedUserId(req);
@@ -2003,6 +2119,11 @@ try {
     }
   });
   console.log(`[Database] ✅ Loaded ${dbChannels.length} channels from database`);
+
+
+  if (settingsRepository.expireRaidModeIfNeeded()) {
+    console.log('[RaidMode] Auto-expired raid mode during startup');
+  }
 } catch (error) {
   console.error('[Database] ❌ Initialization failed:', error);
   process.exit(1);
@@ -2021,6 +2142,16 @@ setInterval(() => {
     console.log(`[Cleanup] 🗑️ Purged ${purged} soft-deleted messages from DB`);
   }
 }, 60 * 60 * 1000); // 1 hour
+
+
+// Raid mode expiry tick (every minute)
+setInterval(() => {
+  const expired = settingsRepository.expireRaidModeIfNeeded();
+  if (expired) {
+    console.log('[RaidMode] Auto-expired raid mode on periodic tick');
+    emitRaidModeToStaffClients();
+  }
+}, 60 * 1000);
 
 // Cleanup on shutdown
 process.on('SIGINT', () => {
@@ -2050,6 +2181,16 @@ function emitToChannel(channelId: string, event: string, data: any) {
   } else {
     // For public channels, broadcast to everyone
     io.emit(event, data);
+  }
+}
+
+
+function emitRaidModeToStaffClients() {
+  const raidModeState = getRaidModeState();
+  for (const [socketId, user] of users.entries()) {
+    if (isStaffRole(user.highestRole)) {
+      io.to(socketId).emit('raid-mode-updated', raidModeState);
+    }
   }
 }
 
@@ -2426,6 +2567,10 @@ io.on("connection", (socket) => {
           sessionId: (socket as any).sessionId
         });
 
+        if (isStaffRole(roleInfo.highestRole)) {
+          socket.emit('raid-mode-updated', getRaidModeState());
+        }
+
         // Deliver offline messages for registered user
         await deliverOfflineMessages(socket, (socket as any).dbUserId);
 
@@ -2633,6 +2778,10 @@ io.on("connection", (socket) => {
       emojis: emojisData,
       sessionId: sessionId
     });
+
+    if (isStaffRole(rejoinRoleInfo.highestRole)) {
+      socket.emit('raid-mode-updated', getRaidModeState());
+    }
 
     // Deliver offline messages for registered user on rejoin
     if (rejoinDbUserId) {
@@ -2854,6 +3003,15 @@ io.on("connection", (socket) => {
     const channel = channels.get(data.channelId);
     if (!channel) return;
 
+    const senderStableId = getStableUserId(socket);
+    const raidModeActive = settingsRepository.isRaidModeActive();
+    if (!checkMessageRateLimit(senderStableId, raidModeActive)) {
+      socket.emit('channel-error', raidModeActive
+        ? 'Slow down: raid mode is active and message rate limits are stricter.'
+        : 'You are sending messages too quickly. Please slow down.');
+      return;
+    }
+
     // Calculate deletion time: use channel auto-delete setting, or default to 1 day
     const DEFAULT_SERVER_EXPIRATION = 24 * 60 * 60 * 1000; // 1 day in milliseconds
     const deletionTime = channel.autoDeleteAfter
@@ -2861,7 +3019,6 @@ io.on("connection", (socket) => {
       : Date.now() + DEFAULT_SERVER_EXPIRATION;
 
     // Use stable user ID for message identity
-    const senderStableId = getStableUserId(socket);
 
     // Build minimal message object with only present fields
     const message: any = {

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -44,6 +44,9 @@
 	let srtGatewayEnabled = false;
 	let screenShareQualityPreset: ScreenShareQualityPreset = 'auto';
 	let localAppRuntime = false;
+	let raidModeEnabled = false;
+	let raidModeExpiresAtInput = '';
+	let savingRaidMode = false;
 
 	// Theme saving state
 	let savingTheme = false;
@@ -70,6 +73,67 @@
 	let bulkEmojiFiles: { file: File; name: string; preview: string }[] = [];
 	let uploadingBulk = false;
 
+
+	$: isStaff = ['owner', 'admin', 'mod'].includes($currentUser?.highestRole || '');
+	$: isRaidAdmin = ['owner', 'admin'].includes($currentUser?.highestRole || '');
+
+	function toDatetimeLocalValue(timestamp: number | null | undefined): string {
+		if (!timestamp) return '';
+		const d = new Date(timestamp);
+		d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+		return d.toISOString().slice(0, 16);
+	}
+
+	async function loadRaidModeState() {
+		if (!browser || !isStaff) return;
+		const authToken = localStorage.getItem('authToken');
+		if (!authToken) return;
+		try {
+			const res = await fetch(`${getServerUrl()}/api/admin/raid-mode`, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${authToken}` }
+			});
+			if (!res.ok) return;
+			const data = await res.json();
+			raidModeEnabled = !!data.raidModeEnabled;
+			raidModeExpiresAtInput = toDatetimeLocalValue(data.raidModeExpiresAt);
+		} catch (error) {
+			console.error('Failed to load raid mode state:', error);
+		}
+	}
+
+	async function saveRaidModeState() {
+		if (!browser || !isRaidAdmin) return;
+		const authToken = localStorage.getItem('authToken');
+		if (!authToken) return;
+
+		savingRaidMode = true;
+		try {
+			const raidModeExpiresAt = raidModeEnabled && raidModeExpiresAtInput
+				? new Date(raidModeExpiresAtInput).getTime()
+				: null;
+
+			const res = await fetch(`${getServerUrl()}/api/admin/raid-mode`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${authToken}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ raidModeEnabled, raidModeExpiresAt })
+			});
+
+			if (!res.ok) {
+				const data = await res.json();
+				throw new Error(data.error || 'Failed to save raid mode');
+			}
+		} catch (error) {
+			console.error('Failed to save raid mode state:', error);
+			alert('Failed to save raid mode state.');
+		} finally {
+			savingRaidMode = false;
+		}
+	}
+
 	// Load settings from localStorage and enforce server policy
 	onMount(() => {
 		soundEnabled = localStorage.getItem('soundEnabled') !== 'false';
@@ -87,7 +151,19 @@
 			mediaQualityMode = getStoredMediaQualityMode();
 			srtGatewayEnabled = isSrtGatewayEnabled();
 			screenShareQualityPreset = getStoredScreenShareQualityPreset();
+			await loadRaidModeState();
 		})();
+
+		const socket = getSocket();
+		const onRaidModeUpdated = (payload: { raidModeEnabled: boolean; raidModeExpiresAt: number | null }) => {
+			raidModeEnabled = !!payload.raidModeEnabled;
+			raidModeExpiresAtInput = toDatetimeLocalValue(payload.raidModeExpiresAt);
+		};
+		socket?.on('raid-mode-updated', onRaidModeUpdated);
+
+		return () => {
+			socket?.off('raid-mode-updated', onRaidModeUpdated);
+		};
 	});
 
 	function toggleSound() {
@@ -781,6 +857,34 @@
 						<UniformFontMode />
 					</div>
 				</div>
+
+
+				{#if isStaff}
+					<div class="settings-section">
+						<h3>🛡️ Raid Mode (Staff)</h3>
+						<div class="setting-item">
+							<div class="setting-info">
+								<span class="setting-label">Enable Raid Mode</span>
+								<span class="setting-description">Blocks new registrations and increases message rate limiting.</span>
+							</div>
+							<button class="toggle-btn" class:active={raidModeEnabled} on:click={() => raidModeEnabled = !raidModeEnabled} disabled={!isRaidAdmin}>
+								{raidModeEnabled ? 'ON' : 'OFF'}
+							</button>
+						</div>
+						<div class="setting-item">
+							<div class="setting-info">
+								<span class="setting-label">Expiry</span>
+								<span class="setting-description">Optional auto-disable date/time for raid mode.</span>
+							</div>
+							<input type="datetime-local" bind:value={raidModeExpiresAtInput} disabled={!isRaidAdmin || !raidModeEnabled} />
+						</div>
+						{#if isRaidAdmin}
+							<button class="action-btn" on:click={saveRaidModeState} disabled={savingRaidMode}>
+								{savingRaidMode ? 'Saving…' : 'Save Raid Mode'}
+							</button>
+						{/if}
+					</div>
+				{/if}
 
 				<!-- Server Management -->
 				<div class="settings-section">


### PR DESCRIPTION
### Motivation
- Provide an admin-controlled “raid mode” to quickly mitigate attacks by blocking new registrations and tightening message rate limits. 
- Persist the raid-mode state server-side with optional auto-expiry so staff can schedule or auto-clear the restriction. 
- Notify staff clients in real time when raid mode changes so moderators can respond immediately.

### Description
- Database: added `app_settings` table and seeded a singleton row with `raid_mode_enabled` and `raid_mode_expires_at`, and added migrations to ensure columns exist on upgrade (`backend/src/db/schema.sql`, `backend/src/db/database.ts`).
- Repository: extended `SettingsRepository` with `AppSettings` accessors plus `isRaidModeActive()` and `expireRaidModeIfNeeded()` helpers and a `setAppSettings()` method (`backend/src/db/repositories/settingsRepository.ts`).
- Auth: registration and guest->registered upgrade handlers now reject requests while raid mode is active (`handleRegister` and `handleUpgrade` in `backend/src/api/authRoutes.ts`).
- Server: added a per-user in-memory message rate limiter that tightens limits when raid mode is active, admin/staff REST endpoints `GET/POST /api/admin/raid-mode`, startup and periodic expiry tick (every minute) to auto-expire raid mode, and a helper to broadcast `raid-mode-updated` events to staff sockets (`backend/src/server.ts`).
- Frontend: added staff/admin-only UI in `Settings.svelte` (toggle + optional expiry datetime + save action), an initial fetch for raid state, and a socket listener to receive live `raid-mode-updated` broadcasts (`frontend/src/lib/components/Settings.svelte`).

### Testing
- Ran backend build: `npm --prefix backend run build` — succeeded. 
- Ran frontend production build: `npm --prefix frontend run build` — succeeded. 
- Ran frontend type/check: `npm --prefix frontend run check` — failed with many pre-existing TypeScript/Svelte diagnostics unrelated to the raid-mode changes (not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e04e11b4832ab4808f11594a813d)