### PR TITLE
Add moderation triggers: DB model, matcher, server enforcement and admin UI

### DIFF
--- a/backend/src/api/moderationRoutes.ts
+++ b/backend/src/api/moderationRoutes.ts
@@ -1,0 +1,119 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { verifyToken } from '../auth/jwt.js';
+import { sessionRepository } from '../db/repositories/sessionRepository.js';
+import { moderationTriggerRepository } from '../db/repositories/moderationTriggerRepository.js';
+import { getUserRoles } from '../auth/roleMiddleware.js';
+
+function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: Record<string, any>) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function getAuthenticatedUserId(req: IncomingMessage): number | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  try {
+    const token = authHeader.slice(7);
+    const payload = verifyToken(token);
+    const dbSession = sessionRepository.findById(payload.sessionId);
+    if (!dbSession || (dbSession.expires_at && dbSession.expires_at < Date.now())) {
+      return null;
+    }
+    return payload.userId;
+  } catch {
+    return null;
+  }
+}
+
+function isModerator(userId: number): boolean {
+  const roles = getUserRoles(userId);
+  return roles.includes('owner') || roles.includes('admin') || roles.includes('mod');
+}
+
+export async function handleListModerationTriggers(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) return writeJson(res, 401, { success: false, error: 'Unauthorized' });
+  if (!isModerator(userId)) return writeJson(res, 403, { success: false, error: 'Forbidden' });
+
+  const triggers = moderationTriggerRepository.listAll(true);
+  writeJson(res, 200, { success: true, triggers });
+}
+
+export async function handleCreateModerationTrigger(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) return writeJson(res, 401, { success: false, error: 'Unauthorized' });
+  if (!isModerator(userId)) return writeJson(res, 403, { success: false, error: 'Forbidden' });
+
+  try {
+    const body = await parseBody(req);
+    const pattern = typeof body.pattern === 'string' ? body.pattern.trim() : '';
+    const action = body.action === 'ban' ? 'ban' : 'timeout';
+    const duration = typeof body.duration === 'string' ? body.duration.trim() : null;
+    const severity = Math.max(1, Math.min(10, parseInt(String(body.severity ?? 5), 10) || 5));
+    const enabled = body.enabled === false ? 0 : 1;
+
+    if (!pattern) return writeJson(res, 400, { success: false, error: 'pattern is required' });
+
+    const id = moderationTriggerRepository.create({ pattern, action, duration, severity, enabled, created_by: userId });
+    writeJson(res, 201, { success: true, id });
+  } catch (error) {
+    writeJson(res, 400, { success: false, error: error instanceof Error ? error.message : 'Invalid request' });
+  }
+}
+
+export async function handleUpdateModerationTrigger(req: IncomingMessage, res: ServerResponse, triggerId: number): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) return writeJson(res, 401, { success: false, error: 'Unauthorized' });
+  if (!isModerator(userId)) return writeJson(res, 403, { success: false, error: 'Forbidden' });
+
+  try {
+    const body = await parseBody(req);
+    const updates: Record<string, any> = {};
+
+    if (typeof body.pattern === 'string') updates.pattern = body.pattern.trim();
+    if (body.action === 'timeout' || body.action === 'ban') updates.action = body.action;
+    if (body.duration === null || typeof body.duration === 'string') updates.duration = body.duration;
+    if (body.severity !== undefined) updates.severity = Math.max(1, Math.min(10, parseInt(String(body.severity), 10) || 5));
+    if (body.enabled !== undefined) updates.enabled = body.enabled ? 1 : 0;
+
+    const updated = moderationTriggerRepository.update(triggerId, updates);
+    if (!updated) return writeJson(res, 404, { success: false, error: 'Trigger not found or no changes' });
+
+    writeJson(res, 200, { success: true });
+  } catch (error) {
+    writeJson(res, 400, { success: false, error: error instanceof Error ? error.message : 'Invalid request' });
+  }
+}
+
+export async function handleDeleteModerationTrigger(req: IncomingMessage, res: ServerResponse, triggerId: number): Promise<void> {
+  const userId = getAuthenticatedUserId(req);
+  if (!userId) return writeJson(res, 401, { success: false, error: 'Unauthorized' });
+  if (!isModerator(userId)) return writeJson(res, 403, { success: false, error: 'Forbidden' });
+
+  const deleted = moderationTriggerRepository.delete(triggerId);
+  if (!deleted) return writeJson(res, 404, { success: false, error: 'Trigger not found' });
+  writeJson(res, 200, { success: true });
+}

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -145,6 +145,28 @@ function runMigrations() {
 		// Columns may already exist
 	}
 
+
+	// Migration: Create moderation_triggers table
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS moderation_triggers (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				pattern TEXT NOT NULL,
+				action TEXT NOT NULL CHECK(action IN ('timeout','ban')),
+				duration TEXT,
+				severity INTEGER NOT NULL DEFAULT 5,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				created_by INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+			)
+		`);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_moderation_triggers_enabled ON moderation_triggers(enabled, severity DESC)');
+	} catch (e) {
+		console.error('[Database] Migration error creating moderation_triggers:', e);
+	}
+
 	// Migration: Add encryption columns to messages table
 	try {
 		const cols = db.pragma('table_info(messages)') as { name: string }[];

--- a/backend/src/db/repositories/moderationTriggerRepository.ts
+++ b/backend/src/db/repositories/moderationTriggerRepository.ts
@@ -1,0 +1,93 @@
+import db from '../database.js';
+
+export type ModerationAction = 'timeout' | 'ban';
+
+export interface ModerationTrigger {
+  id: number;
+  pattern: string;
+  action: ModerationAction;
+  duration: string | null;
+  severity: number;
+  enabled: number;
+  created_by: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export class ModerationTriggerRepository {
+  listAll(includeDisabled = true): ModerationTrigger[] {
+    const stmt = db.prepare(`
+      SELECT id, pattern, action, duration, severity, enabled, created_by, created_at, updated_at
+      FROM moderation_triggers
+      ${includeDisabled ? '' : 'WHERE enabled = 1'}
+      ORDER BY severity DESC, created_at DESC
+    `);
+    return stmt.all() as ModerationTrigger[];
+  }
+
+  listEnabled(): ModerationTrigger[] {
+    return this.listAll(false);
+  }
+
+  create(data: { pattern: string; action: ModerationAction; duration?: string | null; severity: number; enabled?: number; created_by?: number | null }): number {
+    const stmt = db.prepare(`
+      INSERT INTO moderation_triggers (pattern, action, duration, severity, enabled, created_by, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const now = Date.now();
+    const info = stmt.run(
+      data.pattern,
+      data.action,
+      data.duration ?? null,
+      data.severity,
+      data.enabled ?? 1,
+      data.created_by ?? null,
+      now,
+      now
+    );
+    return info.lastInsertRowid as number;
+  }
+
+  update(id: number, updates: { pattern?: string; action?: ModerationAction; duration?: string | null; severity?: number; enabled?: number }): boolean {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (updates.pattern !== undefined) {
+      fields.push('pattern = ?');
+      values.push(updates.pattern);
+    }
+    if (updates.action !== undefined) {
+      fields.push('action = ?');
+      values.push(updates.action);
+    }
+    if (updates.duration !== undefined) {
+      fields.push('duration = ?');
+      values.push(updates.duration);
+    }
+    if (updates.severity !== undefined) {
+      fields.push('severity = ?');
+      values.push(updates.severity);
+    }
+    if (updates.enabled !== undefined) {
+      fields.push('enabled = ?');
+      values.push(updates.enabled);
+    }
+
+    if (fields.length === 0) return false;
+
+    fields.push('updated_at = ?');
+    values.push(Date.now());
+
+    const stmt = db.prepare(`UPDATE moderation_triggers SET ${fields.join(', ')} WHERE id = ?`);
+    const info = stmt.run(...values, id);
+    return info.changes > 0;
+  }
+
+  delete(id: number): boolean {
+    const stmt = db.prepare('DELETE FROM moderation_triggers WHERE id = ?');
+    const info = stmt.run(id);
+    return info.changes > 0;
+  }
+}
+
+export const moderationTriggerRepository = new ModerationTriggerRepository();

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -125,6 +125,23 @@ CREATE TABLE IF NOT EXISTS guest_codes (
   FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
 );
 
+
+-- Moderation triggers (content policy rules)
+CREATE TABLE IF NOT EXISTS moderation_triggers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pattern TEXT NOT NULL,
+  action TEXT NOT NULL CHECK(action IN ('timeout','ban')),
+  duration TEXT,
+  severity INTEGER NOT NULL DEFAULT 5,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_by INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_triggers_enabled ON moderation_triggers(enabled, severity DESC);
+
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_offline_messages_to_user ON offline_messages(to_user_id, delivered);

--- a/backend/src/moderation/triggerMatcher.ts
+++ b/backend/src/moderation/triggerMatcher.ts
@@ -1,0 +1,60 @@
+import type { ModerationTrigger } from '../db/repositories/moderationTriggerRepository.js';
+
+export interface TriggerMatchResult {
+  trigger: ModerationTrigger;
+  matchedPattern: string;
+  strategy: 'exact-substring' | 'normalized-substring';
+}
+
+export function normalizeForMatch(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]/g, '');
+}
+
+export function findTriggeredRule(messageText: string, triggers: ModerationTrigger[]): TriggerMatchResult | null {
+  const text = (messageText || '').trim();
+  if (!text) return null;
+
+  const lowerText = text.toLowerCase();
+  const normalizedText = normalizeForMatch(text);
+
+  for (const trigger of triggers) {
+    if (!trigger.enabled) continue;
+    const pattern = (trigger.pattern || '').trim();
+    if (!pattern) continue;
+
+    const lowerPattern = pattern.toLowerCase();
+    if (lowerText.includes(lowerPattern)) {
+      return {
+        trigger,
+        matchedPattern: pattern,
+        strategy: 'exact-substring'
+      };
+    }
+
+    const normalizedPattern = normalizeForMatch(pattern);
+    if (normalizedPattern && normalizedText.includes(normalizedPattern)) {
+      return {
+        trigger,
+        matchedPattern: pattern,
+        strategy: 'normalized-substring'
+      };
+    }
+  }
+
+  return null;
+}
+
+export function parseDurationMs(duration: string | null | undefined): number {
+  if (!duration) return 15 * 60 * 1000;
+  const normalized = duration.trim().toLowerCase();
+  const m = normalized.match(/^(\d+)([smhd])$/);
+  if (!m) return 15 * 60 * 1000;
+
+  const n = parseInt(m[1], 10);
+  const unit = m[2];
+  const multiplier = unit === 's' ? 1000 : unit === 'm' ? 60_000 : unit === 'h' ? 3_600_000 : 86_400_000;
+  return n * multiplier;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,6 +19,7 @@ import { handleGetThemePreferences, handleSaveThemePreferences, handleResetTheme
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
 import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
 import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handleListWebhookDeliveries } from "./api/webhookRoutes.js";
+import { handleListModerationTriggers, handleCreateModerationTrigger, handleUpdateModerationTrigger, handleDeleteModerationTrigger } from "./api/moderationRoutes.js";
 import { relayRepository } from "./db/repositories/relayRepository.js";
 import { corsCallback, getCORSHeaders, getAllowedOrigins, isOriginAllowed } from "./config/cors.js";
 import { channelRepository } from "./db/repositories/channelRepository.js";
@@ -26,6 +27,8 @@ import { channelMemberRepository } from "./db/repositories/channelMemberReposito
 import { messageRepository } from "./db/repositories/messageRepository.js";
 import { getUserRoles, assignRole, removeRole } from "./auth/roleMiddleware.js";
 import { dispatchWebhookEvent } from "./webhooks/deliveryService.js";
+import { moderationTriggerRepository } from "./db/repositories/moderationTriggerRepository.js";
+import { findTriggeredRule, parseDurationMs } from "./moderation/triggerMatcher.js";
 
 // Helper: get role info for a user (roles, highest role, display color)
 function getUserRoleInfo(dbUserId?: number): { roles: string[]; highestRole: string; roleColor: string | null } {
@@ -136,6 +139,35 @@ function generateSessionId(): string {
 }
 
 const typingUsers = new Set<string>();
+
+// Moderation runtime state
+const postingTimeouts = new Map<string, number>(); // stable user id -> timeout expiry (ms epoch)
+const bannedUsers = new Set<string>(); // stable user id
+const HIGH_SEVERITY_BAN_THRESHOLD = 8;
+
+function isUserTimedOut(stableUserId: string): { active: boolean; remainingMs?: number } {
+  const timeoutUntil = postingTimeouts.get(stableUserId);
+  if (!timeoutUntil) return { active: false };
+  if (Date.now() >= timeoutUntil) {
+    postingTimeouts.delete(stableUserId);
+    return { active: false };
+  }
+  return { active: true, remainingMs: timeoutUntil - Date.now() };
+}
+
+function isModeratorSocket(socketId: string): boolean {
+  const user = users.get(socketId);
+  const roles = user?.roles || [];
+  return roles.includes('owner') || roles.includes('admin') || roles.includes('mod');
+}
+
+function emitModerationNotification(details: Record<string, any>) {
+  for (const socketId of users.keys()) {
+    if (isModeratorSocket(socketId)) {
+      io.to(socketId).emit('moderation-trigger-hit', details);
+    }
+  }
+}
 
 // Business workspace data - for collaborative business features
 interface BusinessData {
@@ -1026,6 +1058,27 @@ server.on('request', async (req, res) => {
   const webhookDeleteMatch = url.pathname.match(/^\/api\/webhooks\/(\d+)$/);
   if (webhookDeleteMatch && req.method === "DELETE") {
     await handleDeleteWebhook(req, res, parseInt(webhookDeleteMatch[1], 10));
+    return;
+  }
+
+  if (url.pathname === '/api/moderation/triggers' && req.method === 'GET') {
+    await handleListModerationTriggers(req, res);
+    return;
+  }
+
+  if (url.pathname === '/api/moderation/triggers' && req.method === 'POST') {
+    await handleCreateModerationTrigger(req, res);
+    return;
+  }
+
+  const moderationTriggerMatch = url.pathname.match(/^\/api\/moderation\/triggers\/(\d+)$/);
+  if (moderationTriggerMatch && req.method === 'PUT') {
+    await handleUpdateModerationTrigger(req, res, parseInt(moderationTriggerMatch[1], 10));
+    return;
+  }
+
+  if (moderationTriggerMatch && req.method === 'DELETE') {
+    await handleDeleteModerationTrigger(req, res, parseInt(moderationTriggerMatch[1], 10));
     return;
   }
 
@@ -2832,7 +2885,7 @@ io.on("connection", (socket) => {
   });
 
   // Handle chat messages
-  socket.on("message", (data: {
+  const handleSendMessage = (data: {
     text: string;
     type: 'text' | 'gif' | 'file' | 'emoji';
     channelId: string;
@@ -2854,27 +2907,88 @@ io.on("connection", (socket) => {
     const channel = channels.get(data.channelId);
     if (!channel) return;
 
+    const senderStableId = getStableUserId(socket);
+    if (bannedUsers.has(senderStableId)) {
+      socket.emit('moderation-action-applied', {
+        action: 'ban',
+        reason: 'Account is banned from posting'
+      });
+      return;
+    }
+
+    const timeoutState = isUserTimedOut(senderStableId);
+    if (timeoutState.active) {
+      socket.emit('moderation-action-applied', {
+        action: 'timeout',
+        remainingMs: timeoutState.remainingMs,
+        reason: 'You are temporarily blocked from posting'
+      });
+      return;
+    }
+
+    const triggerMatch = findTriggeredRule(data.text, moderationTriggerRepository.listEnabled());
+    if (triggerMatch) {
+      const { trigger } = triggerMatch;
+      const canBan = trigger.action === 'ban' && trigger.severity >= HIGH_SEVERITY_BAN_THRESHOLD;
+      const appliedAction = canBan ? 'ban' : 'timeout';
+      const durationMs = parseDurationMs(trigger.duration);
+
+      if (appliedAction === 'ban') {
+        bannedUsers.add(senderStableId);
+        if ((socket as any).dbUserId) {
+          userRepository.update((socket as any).dbUserId, { is_active: 0 });
+        }
+      } else {
+        postingTimeouts.set(senderStableId, Date.now() + durationMs);
+      }
+
+      socket.emit('moderation-action-applied', {
+        action: appliedAction,
+        triggerId: trigger.id,
+        pattern: trigger.pattern,
+        severity: trigger.severity,
+        duration: trigger.duration,
+        durationMs
+      });
+
+      emitModerationNotification({
+        triggerId: trigger.id,
+        pattern: trigger.pattern,
+        strategy: triggerMatch.strategy,
+        severity: trigger.severity,
+        configuredAction: trigger.action,
+        appliedAction,
+        duration: trigger.duration,
+        messageText: data.text,
+        channelId: data.channelId,
+        userId: senderStableId,
+        username: user.username,
+        timestamp: Date.now()
+      });
+
+      if (appliedAction === 'ban') {
+        socket.emit('channel-error', 'Your account has been banned from posting.');
+      }
+      return;
+    }
+
     // Calculate deletion time: use channel auto-delete setting, or default to 1 day
     const DEFAULT_SERVER_EXPIRATION = 24 * 60 * 60 * 1000; // 1 day in milliseconds
     const deletionTime = channel.autoDeleteAfter
       ? Date.now() + getAutoDeleteMs(channel.autoDeleteAfter)
       : Date.now() + DEFAULT_SERVER_EXPIRATION;
 
-    // Use stable user ID for message identity
-    const senderStableId = getStableUserId(socket);
-
     // Build minimal message object with only present fields
     const message: any = {
       id: `${Date.now()}-${senderStableId}`,
       user: user.username,
-      userId: socket.id, // Current socket.id for realtime identification
+      userId: socket.id,
       text: data.text,
       timestamp: Date.now(),
       type: data.type,
       scheduledDeletionTime: deletionTime
     };
 
-    // Only add optional fields if they exist (reduces payload size by 30-40%)
     if (data.gifUrl) message.gifUrl = data.gifUrl;
     if (data.emojiUrl) message.emojiUrl = data.emojiUrl;
     if (data.emojiName) message.emojiName = data.emojiName;
@@ -2887,12 +3001,10 @@ io.on("connection", (socket) => {
     if (data.encrypted) message.encrypted = true;
     if (data.iv) message.iv = data.iv;
 
-    // Add message to channel
     const messages = channelMessages.get(data.channelId) || [];
     messages.push(message);
     channelMessages.set(data.channelId, messages);
 
-    // Notify DM recipient on first message (lazy channel delivery)
     if (channel.type === 'dm' && !channel.recipientNotified && channel.members) {
       const myStableId = getStableUserId(socket);
       const recipientStableId = channel.members.find(m => m !== myStableId);
@@ -2917,11 +3029,9 @@ io.on("connection", (socket) => {
 
     emitToChannel(data.channelId, "message", { channelId: data.channelId, message });
 
-    // Schedule auto-deletion for ALL messages (either custom time or default 1-day)
     const deletionDuration = channel.autoDeleteAfter || '24h';
     scheduleMessageDeletion(data.channelId, message.id, deletionDuration);
 
-    // Persist message to database with stable sender ID
     try {
       messageRepository.create({
         message_id: message.id,
@@ -2961,20 +3071,20 @@ io.on("connection", (socket) => {
       console.error('[Webhooks] Failed to dispatch message.created:', error);
     });
 
-    // Clear typing indicator for this channel
     if (typingUsers.has(socket.id)) {
       typingUsers.delete(socket.id);
 
-      // Also remove from channel-specific typing users
       const channelTyping = channelTypingUsers.get(data.channelId);
       if (channelTyping) {
         channelTyping.delete(socket.id);
-        // Emit updated typing list only to users in this channel
         const typingUsernames = Array.from(channelTyping).map(id => users.get(id)?.username).filter(Boolean);
         emitToChannel(data.channelId, "typing", { channelId: data.channelId, usernames: typingUsernames });
       }
     }
-  });
+  };
+
+  socket.on("message", handleSendMessage);
+  socket.on("send-message", handleSendMessage);
 
   // Handle message edit
   socket.on("edit-message", (data: { messageId: string; newText: string; channelId: string }) => {

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -70,6 +70,33 @@
 	let bulkEmojiFiles: { file: File; name: string; preview: string }[] = [];
 	let uploadingBulk = false;
 
+
+	type ModerationTrigger = {
+		id: number;
+		pattern: string;
+		action: 'timeout' | 'ban';
+		duration: string | null;
+		severity: number;
+		enabled: number;
+	};
+
+	let moderationTriggers: ModerationTrigger[] = [];
+	let moderationLoading = false;
+	let moderationError = '';
+	let moderationPattern = '';
+	let moderationAction: 'timeout' | 'ban' = 'timeout';
+	let moderationDuration = '15m';
+	let moderationSeverity = 5;
+	let editingTriggerId: number | null = null;
+	$: canManageModeration = !!$currentUser?.roles?.some((r) => ['owner', 'admin', 'mod'].includes(r));
+	$: moderationActionPreview = moderationAction === 'ban' && moderationSeverity >= 8
+		? 'Preview: High-severity trigger will ban the sender.'
+		: `Preview: Sender will be timed out for ${moderationDuration || '15m'}.`;
+
+	$: if (isOpen && canManageModeration && !moderationLoading && moderationTriggers.length === 0) {
+		void loadModerationTriggers();
+	}
+
 	// Load settings from localStorage and enforce server policy
 	onMount(() => {
 		soundEnabled = localStorage.getItem('soundEnabled') !== 'false';
@@ -87,6 +114,7 @@
 			mediaQualityMode = getStoredMediaQualityMode();
 			srtGatewayEnabled = isSrtGatewayEnabled();
 			screenShareQualityPreset = getStoredScreenShareQualityPreset();
+			if (canManageModeration) await loadModerationTriggers();
 		})();
 	});
 
@@ -206,6 +234,85 @@
 		}
 	}
 
+
+
+	async function loadModerationTriggers() {
+		if (!canManageModeration) return;
+		moderationLoading = true;
+		moderationError = '';
+		try {
+			const token = browser ? localStorage.getItem('authToken') : null;
+			const response = await fetch(`${getServerUrl()}/api/moderation/triggers`, {
+				headers: token ? { Authorization: `Bearer ${token}` } : {}
+			});
+			const data = await response.json();
+			if (!response.ok || !data.success) throw new Error(data.error || 'Failed to load moderation triggers');
+			moderationTriggers = data.triggers;
+		} catch (error) {
+			moderationError = error instanceof Error ? error.message : 'Failed to load moderation triggers';
+		} finally {
+			moderationLoading = false;
+		}
+	}
+
+	function startEditTrigger(trigger: ModerationTrigger) {
+		editingTriggerId = trigger.id;
+		moderationPattern = trigger.pattern;
+		moderationAction = trigger.action;
+		moderationDuration = trigger.duration || '15m';
+		moderationSeverity = trigger.severity;
+	}
+
+	function resetModerationForm() {
+		editingTriggerId = null;
+		moderationPattern = '';
+		moderationAction = 'timeout';
+		moderationDuration = '15m';
+		moderationSeverity = 5;
+	}
+
+	async function saveModerationTrigger() {
+		const token = browser ? localStorage.getItem('authToken') : null;
+		if (!token || !moderationPattern.trim()) return;
+		const method = editingTriggerId ? 'PUT' : 'POST';
+		const endpoint = editingTriggerId
+			? `${getServerUrl()}/api/moderation/triggers/${editingTriggerId}`
+			: `${getServerUrl()}/api/moderation/triggers`;
+		const payload = {
+			pattern: moderationPattern.trim(),
+			action: moderationAction,
+			duration: moderationDuration.trim() || null,
+			severity: moderationSeverity,
+			enabled: true
+		};
+		const response = await fetch(endpoint, {
+			method,
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+			body: JSON.stringify(payload)
+		});
+		const data = await response.json();
+		if (!response.ok || !data.success) {
+			moderationError = data.error || 'Failed to save moderation trigger';
+			return;
+		}
+		resetModerationForm();
+		await loadModerationTriggers();
+	}
+
+	async function deleteModerationTrigger(id: number) {
+		const token = browser ? localStorage.getItem('authToken') : null;
+		if (!token) return;
+		const response = await fetch(`${getServerUrl()}/api/moderation/triggers/${id}`, {
+			method: 'DELETE',
+			headers: { Authorization: `Bearer ${token}` }
+		});
+		const data = await response.json();
+		if (!response.ok || !data.success) {
+			moderationError = data.error || 'Failed to delete moderation trigger';
+			return;
+		}
+		await loadModerationTriggers();
+	}
 	function clearAllData() {
 		showClearDataConfirm = true;
 	}
@@ -781,6 +888,44 @@
 						<UniformFontMode />
 					</div>
 				</div>
+
+
+				{#if canManageModeration}
+					<div class="settings-section">
+						<h3>🛡️ Moderation Triggers</h3>
+						<div class="setting-item moderation-form">
+							<input class="emoji-name-input" type="text" bind:value={moderationPattern} placeholder="Pattern to match" />
+							<select bind:value={moderationAction} class="emoji-category-select">
+								<option value="timeout">timeout</option>
+								<option value="ban">ban</option>
+							</select>
+							<input class="emoji-name-input duration-input" type="text" bind:value={moderationDuration} placeholder="Duration (e.g. 15m, 2h)" />
+							<input type="range" min="1" max="10" bind:value={moderationSeverity} />
+							<span class="setting-description">Severity: {moderationSeverity}</span>
+							<button class="action-btn" on:click={saveModerationTrigger} disabled={!moderationPattern.trim()}>
+								{editingTriggerId ? '💾 Update Rule' : '➕ Add Rule'}
+							</button>
+							{#if editingTriggerId}
+								<button class="action-btn" on:click={resetModerationForm}>Cancel</button>
+							{/if}
+						</div>
+						<p class="setting-description">{moderationActionPreview}</p>
+						{#if moderationError}<p class="setting-description" style="color: #ff6b6b;">{moderationError}</p>{/if}
+						{#if moderationLoading}
+							<p class="setting-description">Loading moderation rules…</p>
+						{:else}
+							<div class="emoji-list">
+								{#each moderationTriggers as trigger (trigger.id)}
+									<div class="emoji-item">
+										<span class="emoji-item-name">{trigger.pattern} → {trigger.action} ({trigger.duration || 'default'}, sev {trigger.severity})</span>
+										<button class="emoji-select-btn" on:click={() => startEditTrigger(trigger)}>Edit</button>
+										<button class="emoji-delete-btn" on:click={() => deleteModerationTrigger(trigger.id)}>🗑️</button>
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
 
 				<!-- Server Management -->
 				<div class="settings-section">
@@ -1790,4 +1935,14 @@
 		opacity: 1;
 		color: var(--color-danger);
 	}
+
+	.moderation-form {
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.duration-input {
+		max-width: 180px;
+	}
+
 </style>


### PR DESCRIPTION
### Motivation
- Provide a configurable, server-enforced moderation pipeline so messages can be automatically timed out or banned when they match policy rules. 
- Ensure moderators are notified in real time when a rule is hit and give admins an interface to manage rules and preview actions.

### Description
- Persisted a new `moderation_triggers` table and index and added a safe startup migration so existing DBs get the table; added a `ModerationTriggerRepository` for CRUD and listing.\
- Implemented a matcher module (`findTriggeredRule`, `normalizeForMatch`, `parseDurationMs`) that checks exact substring matches first and then normalized substring matches.\
- Integrated enforcement into the socket message flow by centralizing message handling into `handleSendMessage` and registering it for both `message` and `send-message`, applying configured actions (`timeout` or severity-gated `ban`) before broadcast and persistence.\
- Emitted moderator notifications via a new `moderation-trigger-hit` event with trigger and match details, and added moderator-only HTTP endpoints (`GET/POST/PUT/DELETE /api/moderation/triggers`) plus a simple admin UI in `Settings.svelte` to create/edit/delete triggers and show an action preview. 

### Testing
- Built the backend with `npm --prefix backend run build` and the build succeeded.\
- Built the frontend with `npm --prefix frontend run build` and the build succeeded.\
- Ran `npm --prefix frontend run check` which failed due to pre-existing TypeScript/svelte-check issues unrelated to this change set (reported as warnings/errors across many files).\
- Attempted a Playwright screenshot to validate the UI, but Chromium crashed (SIGSEGV) in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e04fb07c832ab21e45b7a7d6f75d)