### PR TITLE
Add admin job queue worker with progress events and paginated admin APIs

### DIFF
--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -145,6 +145,27 @@ function runMigrations() {
 		// Columns may already exist
 	}
 
+
+	// Migration: Add admin_jobs table for async admin tasks
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS admin_jobs (
+				job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				type TEXT NOT NULL,
+				payload TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'queued',
+				progress INTEGER NOT NULL DEFAULT 0,
+				created_by INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_admin_jobs_status_created ON admin_jobs(status, created_at);
+		`);
+	} catch (e) {
+		console.error('[Database] Migration error adding admin_jobs table:', e);
+	}
+
 	// Migration: Add encryption columns to messages table
 	try {
 		const cols = db.pragma('table_info(messages)') as { name: string }[];

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -251,3 +251,18 @@ CREATE INDEX IF NOT EXISTS idx_webhooks_user ON webhooks(user_id);
 CREATE INDEX IF NOT EXISTS idx_webhooks_enabled ON webhooks(enabled);
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook ON webhook_deliveries(webhook_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status, updated_at);
+
+-- Admin async job queue
+CREATE TABLE IF NOT EXISTS admin_jobs (
+  job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued', -- queued|running|completed|failed
+  progress INTEGER NOT NULL DEFAULT 0,
+  created_by INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (created_by) REFERENCES users(user_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_jobs_status_created ON admin_jobs(status, created_at);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -44,6 +44,37 @@ function getUserRoleInfo(dbUserId?: number): { roles: string[]; highestRole: str
 
   return { roles: roles.length > 0 ? roles : ['member'], highestRole, roleColor };
 }
+
+
+type AdminJobStatus = 'queued' | 'running' | 'completed' | 'failed';
+type AdminJobType = 'bulk-role-update' | 'stale-structure-cleanup';
+
+interface AdminJobRecord {
+  job_id: number;
+  type: AdminJobType;
+  payload: string;
+  status: AdminJobStatus;
+  progress: number;
+  created_by: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+function isAdminUser(dbUserId?: number): boolean {
+  if (!dbUserId) return false;
+  const roleInfo = getUserRoleInfo(dbUserId);
+  return ['owner', 'admin'].includes(roleInfo.highestRole);
+}
+
+function emitAdminJobEvent(createdBy: number | null | undefined, event: string, payload: any) {
+  if (!createdBy) return;
+  const socketId = dbUserIdToSocketId.get(createdBy);
+  if (socketId) io.to(socketId).emit(event, payload);
+}
+
+function sleepTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 // In-memory data store
 interface Channel {
   id: string;
@@ -1080,6 +1111,62 @@ server.on('request', async (req, res) => {
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: 'Failed to fetch users' }));
     }
+    return;
+  }
+
+
+  // Admin channels list (paginated)
+  if (url.pathname === "/api/admin/channels" && req.method === "GET") {
+    const userId = getAuthenticatedUserId(req);
+    if (!isAdminUser(userId || undefined)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+      return;
+    }
+
+    const page = Math.max(1, Number(url.searchParams.get('page') || '1'));
+    const limit = Math.min(100, Math.max(1, Number(url.searchParams.get('limit') || '50')));
+    const offset = (page - 1) * limit;
+
+    const totalRow = db.prepare('SELECT COUNT(*) as count FROM channels WHERE is_archived = 0').get() as { count: number };
+    const rows = db.prepare(`
+      SELECT channel_id, channel_type, name, description, created_at, created_by, persist_messages, avatar
+      FROM channels
+      WHERE is_archived = 0
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    `).all(limit, offset);
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ items: rows, page, limit, total: totalRow.count, hasMore: offset + rows.length < totalRow.count }));
+    return;
+  }
+
+  // Admin roles list (paginated)
+  if (url.pathname === "/api/admin/roles" && req.method === "GET") {
+    const userId = getAuthenticatedUserId(req);
+    if (!isAdminUser(userId || undefined)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+      return;
+    }
+
+    const page = Math.max(1, Number(url.searchParams.get('page') || '1'));
+    const limit = Math.min(100, Math.max(1, Number(url.searchParams.get('limit') || '50')));
+    const offset = (page - 1) * limit;
+
+    const totalRow = db.prepare('SELECT COUNT(*) as count FROM roles').get() as { count: number };
+    const rows = db.prepare(`
+      SELECT r.role_name, r.workspace_id, r.priority, r.color, r.is_hoisted, COUNT(ur.id) as assigned_users
+      FROM roles r
+      LEFT JOIN user_roles ur ON ur.role_name = r.role_name AND ur.workspace_id = r.workspace_id
+      GROUP BY r.role_name, r.workspace_id, r.priority, r.color, r.is_hoisted
+      ORDER BY r.priority DESC, r.role_name ASC
+      LIMIT ? OFFSET ?
+    `).all(limit, offset);
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ items: rows, page, limit, total: totalRow.count, hasMore: offset + rows.length < totalRow.count }));
     return;
   }
 
@@ -2356,6 +2443,169 @@ async function deliverOfflineMessages(socket: any, dbUserId: number | null) {
     console.error('[Offline] Failed to deliver offline messages:', error);
   }
 }
+
+
+
+function createAdminJob(type: AdminJobType, payload: any, createdBy: number): number {
+  const now = Date.now();
+  const result = db.prepare(
+    'INSERT INTO admin_jobs (type, payload, status, progress, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(type, JSON.stringify(payload), 'queued', 0, createdBy, now, now);
+  return Number(result.lastInsertRowid);
+}
+
+function updateAdminJob(jobId: number, status: AdminJobStatus, progress: number) {
+  const now = Date.now();
+  db.prepare('UPDATE admin_jobs SET status = ?, progress = ?, updated_at = ? WHERE job_id = ?').run(status, Math.max(0, Math.min(100, progress)), now, jobId);
+}
+
+async function processBulkRoleUpdateJob(job: AdminJobRecord) {
+  const payload = JSON.parse(job.payload) as { operations: Array<{ targetUserId: number; roleName: string; action: 'assign' | 'remove' }> };
+  const total = payload.operations?.length || 0;
+  if (total === 0) {
+    updateAdminJob(job.job_id, 'completed', 100);
+    emitAdminJobEvent(job.created_by, 'admin-job-complete', { jobId: job.job_id, type: job.type, progress: 100, result: { processed: 0 } });
+    return;
+  }
+
+  updateAdminJob(job.job_id, 'running', 1);
+  const chunkSize = 25;
+  let processed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < total; i += chunkSize) {
+    const batch = payload.operations.slice(i, i + chunkSize);
+    for (const op of batch) {
+      try {
+        if (op.action === 'remove') {
+          removeRole(op.targetUserId, op.roleName as any, 'default-workspace');
+        } else {
+          assignRole(op.targetUserId, op.roleName as any);
+        }
+
+        const newRoleInfo = getUserRoleInfo(op.targetUserId);
+        for (const [sid, u] of users.entries()) {
+          if (u.dbUserId === op.targetUserId) {
+            u.roles = newRoleInfo.roles;
+            u.highestRole = newRoleInfo.highestRole;
+            u.roleColor = newRoleInfo.roleColor;
+            users.set(sid, u);
+            io.emit('user-role-changed', {
+              userId: sid,
+              dbUserId: op.targetUserId,
+              roles: newRoleInfo.roles,
+              highestRole: newRoleInfo.highestRole,
+              roleColor: newRoleInfo.roleColor
+            });
+            break;
+          }
+        }
+      } catch {
+        failed++;
+      }
+      processed++;
+    }
+
+    const progress = Math.round((processed / total) * 100);
+    updateAdminJob(job.job_id, 'running', progress);
+    emitAdminJobEvent(job.created_by, 'admin-job-progress', { jobId: job.job_id, type: job.type, progress, result: { processed, total, failed } });
+    await sleepTick();
+  }
+
+  updateAdminJob(job.job_id, 'completed', 100);
+  emitAdminJobEvent(job.created_by, 'admin-job-complete', { jobId: job.job_id, type: job.type, progress: 100, result: { processed, total, failed } });
+}
+
+async function processStaleStructureCleanupJob(job: AdminJobRecord) {
+  const payload = JSON.parse(job.payload) as { mode: 'dry-run' | 'apply' };
+  const apply = payload.mode === 'apply';
+  updateAdminJob(job.job_id, 'running', 1);
+
+  const orphanMessageChannels = Array.from(channelMessages.keys()).filter((channelId) => !channels.has(channelId));
+  const orphanPinnedChannels = Array.from(pinnedMessages.keys()).filter((channelId) => !channels.has(channelId));
+  const missingDbChannels = Array.from(channels.keys()).filter((channelId) => {
+    if (channelId === 'general') return false;
+    return !channelRepository.exists(channelId);
+  });
+
+  const totalTasks = orphanMessageChannels.length + orphanPinnedChannels.length + missingDbChannels.length || 1;
+  let done = 0;
+
+  for (const channelId of orphanMessageChannels) {
+    if (apply) channelMessages.delete(channelId);
+    done++;
+    const progress = Math.round((done / totalTasks) * 100);
+    updateAdminJob(job.job_id, 'running', progress);
+    emitAdminJobEvent(job.created_by, 'admin-job-progress', { jobId: job.job_id, type: job.type, progress });
+    await sleepTick();
+  }
+
+  for (const channelId of orphanPinnedChannels) {
+    if (apply) pinnedMessages.delete(channelId);
+    done++;
+    const progress = Math.round((done / totalTasks) * 100);
+    updateAdminJob(job.job_id, 'running', progress);
+    emitAdminJobEvent(job.created_by, 'admin-job-progress', { jobId: job.job_id, type: job.type, progress });
+    await sleepTick();
+  }
+
+  for (const channelId of missingDbChannels) {
+    if (apply) channels.delete(channelId);
+    done++;
+    const progress = Math.round((done / totalTasks) * 100);
+    updateAdminJob(job.job_id, 'running', progress);
+    emitAdminJobEvent(job.created_by, 'admin-job-progress', { jobId: job.job_id, type: job.type, progress });
+    await sleepTick();
+  }
+
+  updateAdminJob(job.job_id, 'completed', 100);
+  emitAdminJobEvent(job.created_by, 'admin-job-complete', {
+    jobId: job.job_id,
+    type: job.type,
+    progress: 100,
+    result: {
+      mode: payload.mode,
+      orphanMessageChannels: orphanMessageChannels.length,
+      orphanPinnedChannels: orphanPinnedChannels.length,
+      missingDbChannels: missingDbChannels.length,
+      applied: apply
+    }
+  });
+}
+
+let processingAdminJobs = false;
+async function processNextAdminJob() {
+  if (processingAdminJobs) return;
+  processingAdminJobs = true;
+  try {
+    const job = db.prepare("SELECT * FROM admin_jobs WHERE status = 'queued' ORDER BY created_at ASC LIMIT 1").get() as AdminJobRecord | undefined;
+    if (!job) return;
+
+    try {
+      if (job.type === 'bulk-role-update') {
+        await processBulkRoleUpdateJob(job);
+      } else if (job.type === 'stale-structure-cleanup') {
+        await processStaleStructureCleanupJob(job);
+      } else {
+        throw new Error(`Unsupported job type: ${job.type}`);
+      }
+    } catch (error: any) {
+      updateAdminJob(job.job_id, 'failed', 100);
+      emitAdminJobEvent(job.created_by, 'admin-job-failed', {
+        jobId: job.job_id,
+        type: job.type,
+        progress: 100,
+        error: error?.message || 'Job failed'
+      });
+    }
+  } finally {
+    processingAdminJobs = false;
+  }
+}
+
+setInterval(() => {
+  processNextAdminJob().catch((err) => console.error('[AdminJobs] Worker loop error:', err));
+}, 300);
 
 io.on("connection", (socket) => {
   console.log(`🔌 WebSocket connection established: ${socket.id}`);
@@ -3790,6 +4040,42 @@ io.on("connection", (socket) => {
     } catch (e) {
       socket.emit("channel-error", "Failed to remove role");
     }
+  });
+
+
+  socket.on("queue-bulk-role-update", (data: { operations: Array<{ targetUserId: number; roleName: string; action: 'assign' | 'remove' }> }) => {
+    const user = users.get(socket.id);
+    if (!user || !user.dbUserId) return;
+
+    if (!isAdminUser(user.dbUserId)) {
+      socket.emit("channel-error", "Insufficient permissions to queue role updates");
+      return;
+    }
+
+    const operations = (data.operations || []).filter((op) => op && op.targetUserId && op.roleName && (op.action === 'assign' || op.action === 'remove'));
+    if (operations.length === 0) {
+      socket.emit("channel-error", "No valid role update operations");
+      return;
+    }
+
+    const jobId = createAdminJob('bulk-role-update', { operations }, user.dbUserId);
+    socket.emit('admin-job-progress', { jobId, type: 'bulk-role-update', progress: 0, queued: true });
+    processNextAdminJob().catch((err) => console.error('[AdminJobs] trigger error:', err));
+  });
+
+  socket.on("queue-stale-structure-cleanup", (data: { mode?: 'dry-run' | 'apply' }) => {
+    const user = users.get(socket.id);
+    if (!user || !user.dbUserId) return;
+
+    if (!isAdminUser(user.dbUserId)) {
+      socket.emit("channel-error", "Insufficient permissions to queue cleanup");
+      return;
+    }
+
+    const mode = data?.mode === 'apply' ? 'apply' : 'dry-run';
+    const jobId = createAdminJob('stale-structure-cleanup', { mode }, user.dbUserId);
+    socket.emit('admin-job-progress', { jobId, type: 'stale-structure-cleanup', progress: 0, queued: true, mode });
+    processNextAdminJob().catch((err) => console.error('[AdminJobs] trigger error:', err));
   });
 
   // Group chat creation

--- a/frontend/src/lib/admin-lists.ts
+++ b/frontend/src/lib/admin-lists.ts
@@ -1,0 +1,37 @@
+import { writable, get } from 'svelte/store';
+import { getAdminChannels, getAdminRoles, type AdminChannelListItem, type AdminRoleListItem } from './api';
+
+export const adminChannels = writable<AdminChannelListItem[]>([]);
+export const adminChannelsPage = writable(0);
+export const adminChannelsHasMore = writable(true);
+
+export const adminRoles = writable<AdminRoleListItem[]>([]);
+export const adminRolesPage = writable(0);
+export const adminRolesHasMore = writable(true);
+
+export async function loadNextAdminChannels(token: string, limit = 50): Promise<void> {
+	if (!get(adminChannelsHasMore)) return;
+	const nextPage = get(adminChannelsPage) + 1;
+	const res = await getAdminChannels(token, nextPage, limit);
+	adminChannels.update((items) => [...items, ...res.items]);
+	adminChannelsPage.set(res.page);
+	adminChannelsHasMore.set(res.hasMore);
+}
+
+export async function loadNextAdminRoles(token: string, limit = 50): Promise<void> {
+	if (!get(adminRolesHasMore)) return;
+	const nextPage = get(adminRolesPage) + 1;
+	const res = await getAdminRoles(token, nextPage, limit);
+	adminRoles.update((items) => [...items, ...res.items]);
+	adminRolesPage.set(res.page);
+	adminRolesHasMore.set(res.hasMore);
+}
+
+export function resetAdminLazyLists() {
+	adminChannels.set([]);
+	adminChannelsPage.set(0);
+	adminChannelsHasMore.set(true);
+	adminRoles.set([]);
+	adminRolesPage.set(0);
+	adminRolesHasMore.set(true);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -180,3 +180,57 @@ export async function saveUserSettings(
 		clearTimeout(timeout);
 	}
 }
+
+export interface PaginatedResponse<T> {
+	items: T[];
+	page: number;
+	limit: number;
+	total: number;
+	hasMore: boolean;
+}
+
+export interface AdminChannelListItem {
+	channel_id: string;
+	channel_type: 'public' | 'dm' | 'group';
+	name: string;
+	description: string;
+	created_at: number;
+	created_by?: string;
+	persist_messages: number;
+	avatar?: string | null;
+}
+
+export interface AdminRoleListItem {
+	role_name: string;
+	workspace_id: string;
+	priority: number;
+	color: string | null;
+	is_hoisted: number;
+	assigned_users: number;
+}
+
+export async function getAdminChannels(token: string, page = 1, limit = 50): Promise<PaginatedResponse<AdminChannelListItem>> {
+	const res = await fetch(`${SERVER_URL}/api/admin/channels?page=${page}&limit=${limit}`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (!res.ok) {
+		throw new Error('Failed to load admin channels');
+	}
+
+	return res.json();
+}
+
+export async function getAdminRoles(token: string, page = 1, limit = 50): Promise<PaginatedResponse<AdminRoleListItem>> {
+	const res = await fetch(`${SERVER_URL}/api/admin/roles?page=${page}&limit=${limit}`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (!res.ok) {
+		throw new Error('Failed to load admin roles');
+	}
+
+	return res.json();
+}

--- a/frontend/src/lib/socket-manager.ts
+++ b/frontend/src/lib/socket-manager.ts
@@ -118,6 +118,18 @@ export const channelOldestMessageId = writable<Record<string, string | null>>({}
 // Connection state for UI feedback
 export const connectionState = writable<ConnectionState>('disconnected');
 
+export interface AdminJobEvent {
+	jobId: number;
+	type: 'bulk-role-update' | 'stale-structure-cleanup';
+	progress: number;
+	queued?: boolean;
+	mode?: 'dry-run' | 'apply';
+	result?: any;
+	error?: string;
+}
+
+export const adminJobEvents = writable<AdminJobEvent[]>([]);
+
 // ============================================================================
 // SOCKET MANAGER CLASS - Singleton with State Machine
 // ============================================================================
@@ -584,7 +596,7 @@ class SocketManager {
 
 			// Initialize pagination state from server response
 			if (data.hasMore !== undefined) {
-				channelHasMoreHistory.update(s => ({ ...s, [data.channelId]: data.hasMore }));
+				channelHasMoreHistory.update(s => ({ ...s, [data.channelId]: Boolean(data.hasMore) }));
 			}
 			if (data.messages.length > 0) {
 				channelOldestMessageId.update(s => ({ ...s, [data.channelId]: data.messages[0].id }));
@@ -622,7 +634,7 @@ class SocketManager {
 			});
 
 			// Update pagination state
-			channelHasMoreHistory.update(s => ({ ...s, [data.channelId]: data.hasMore }));
+			channelHasMoreHistory.update(s => ({ ...s, [data.channelId]: Boolean(data.hasMore) }));
 			channelHistoryLoading.update(s => ({ ...s, [data.channelId]: false }));
 
 			// Track oldest message for pagination
@@ -851,6 +863,20 @@ class SocketManager {
 					? { ...cu, roles: data.roles, highestRole: data.highestRole, roleColor: data.roleColor }
 					: cu
 			);
+		});
+
+
+		sock.on('admin-job-progress', (event: AdminJobEvent) => {
+			adminJobEvents.update((events) => [...events.slice(-49), event]);
+		});
+
+		sock.on('admin-job-complete', (event: AdminJobEvent) => {
+			adminJobEvents.update((events) => [...events.slice(-49), event]);
+		});
+
+		sock.on('admin-job-failed', (event: AdminJobEvent) => {
+			adminJobEvents.update((events) => [...events.slice(-49), event]);
+			alert(event.error || 'Admin job failed');
 		});
 
 		sock.on('group-created', (group: Channel) => {
@@ -1486,6 +1512,15 @@ export function assignRole(targetUserId: number, roleName: string): void {
 
 export function removeUserRole(targetUserId: number, roleName: string): void {
 	socketManager.emit('remove-role', { targetUserId, roleName });
+}
+
+
+export function queueBulkRoleUpdate(operations: Array<{ targetUserId: number; roleName: string; action: 'assign' | 'remove' }>): void {
+	socketManager.emit('queue-bulk-role-update', { operations });
+}
+
+export function queueStaleStructureCleanup(mode: 'dry-run' | 'apply' = 'dry-run'): void {
+	socketManager.emit('queue-stale-structure-cleanup', { mode });
 }
 
 export function createGroup(name: string, memberIds: string[]): void {


### PR DESCRIPTION
### Motivation

- Heavy admin operations (bulk role changes, cleanup tasks) can block the event loop and provide poor UX without progress feedback. 
- A persistent async job queue allows long-running admin tasks to run offline from the request/Socket handlers and report progress to operators. 
- Admin lists for channels/roles can be large, so paginated APIs and lazy-loading in the frontend reduce memory and network pressure.

### Description

- Added persistent admin job storage by creating the `admin_jobs` table and index in `backend/src/db/schema.sql` and a startup migration in `backend/src/db/database.ts`.
- Implemented a cooperative backend worker loop and job lifecycle in `backend/src/server.ts` with: `createAdminJob`, `updateAdminJob`, `processBulkRoleUpdateJob`, `processStaleStructureCleanupJob`, and `processNextAdminJob` which run in chunked batches to avoid event-loop blocking.
- Converted heavy admin actions to queued jobs and added socket handlers `queue-bulk-role-update` and `queue-stale-structure-cleanup`, and emit job lifecycle events over sockets: `admin-job-progress`, `admin-job-complete`, and `admin-job-failed` (backend in `backend/src/server.ts`).
- Added paginated admin HTTP APIs `GET /api/admin/channels?page=&limit=` and `GET /api/admin/roles?page=&limit=` (backend in `backend/src/server.ts`).
- Frontend support: added typed admin API helpers `getAdminChannels`/`getAdminRoles` in `frontend/src/lib/api.ts`, a lazy-load admin list store `frontend/src/lib/admin-lists.ts`, admin job event store/listeners in `frontend/src/lib/socket-manager.ts`, and socket helper functions `queueBulkRoleUpdate` and `queueStaleStructureCleanup` to enqueue jobs from the client.

### Testing

- Ran backend build with `cd backend && npm run build`, which succeeded (`esbuild` produced `dist/server.js`).
- Ran frontend static checks with `cd frontend && npm run check`, which reported repository-wide Svelte/TypeScript errors (svelte-check found many pre-existing issues unrelated to this PR); frontend typecheck produced failures and thus is marked as ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e0526474832aa122ade8ad870592)