### PR TITLE
Add durable media gateway control plane with stream leases

### DIFF
--- a/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
+++ b/PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md
@@ -5,7 +5,7 @@
 - Enable higher-quality transport/features for Tauri-native targets without breaking web compatibility.
 - Keep memory/CPU budgets low with graceful degradation.
 
-> Important: this document describes the target architecture. The current implementation only includes WebRTC-side tuning and Opus preference hints; it does **not** include a full SRT media gateway implementation yet.
+> Important: browsers still use WebRTC for interactive sessions. SRT is a server-side/gateway transport and must remain behind a control-plane contract.
 
 ## Transport Modes
 
@@ -24,24 +24,57 @@
   - ingest/relay,
   - recording,
   - distribution pipelines.
-- Gateway must expose a control interface to app backend and preserve auth boundaries.
+- Gateway exposes a dedicated control-plane API contract to the backend with:
+  - runtime registration/readiness,
+  - authenticated heartbeats,
+  - durable stream lease claim/release lifecycle,
+  - audit log entries for gateway actions.
 
-### Current Status
+## Current Status
 - ✅ WebRTC baseline improvements shipped (deafen/video-toggle fixes, sender tuning, Opus preference attempt).
-- ⚠️ SRT gateway not yet shipped (design only in this phase).
+- ✅ Backend control-plane endpoints shipped for gateway runtime + lease lifecycle:
+  - `POST /api/media/gateway/register`
+  - `POST /api/media/gateway-heartbeat`
+  - `POST /api/media/gateway/streams/claim`
+  - `POST /api/media/gateway/streams/release`
+  - `GET /api/media/runtime`
+- ✅ Durable gateway state persisted in SQLite tables (`media_gateway_runtime`, `media_gateway_stream_leases`, `media_gateway_audit_log`).
+- ⚠️ Full external observability stack (dashboards/SLO alerts/runbooks) remains deployment work.
 
 ## Operational Requirements (SRT Gateway)
 - Explicit ports/TLS config in deployment docs.
-- Per-stream auth and ACL rules.
+- Per-stream auth and ACL rules via signed token/rule mapping (`MEDIA_STREAM_ACCESS_RULES`).
 - Metrics: packet loss, jitter, RTT, bitrate, reconnection counts.
 - Fallback to pure WebRTC when gateway unavailable.
 
+## Control Plane Environment Variables
+- `MEDIA_GATEWAY_KEY` (required for gateway control endpoints).
+- `MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS` (health timeout window).
+- `MEDIA_SRT_GATEWAY_ENABLED` and `MEDIA_SRT_GATEWAY_URL` (feature/runtime hints).
+- `MEDIA_STREAM_ACCESS_RULES` JSON map of `x-media-stream-token` to allowed tenant/workspace/channel scope.
+
+Example:
+```json
+{
+  "token-prod-a": {
+    "tenantId": "tenant-a",
+    "workspaceIds": ["workspace-1"],
+    "channelIds": ["voice-general", "voice-stage"]
+  },
+  "token-ops": {
+    "tenantId": "ops",
+    "workspaceIds": ["*"],
+    "channelIds": ["*"]
+  }
+}
+```
+
 ## Rollout Tasks
-1. Fix call control bugs (deafen/video-on upgrade).
-2. Stabilize WebRTC sender tuning (Opus preference + bitrate caps).
-3. Add adaptive quality ladder (resolution/fps/bitrate).
-4. Introduce gateway control hooks for SRT mode (disabled by default).
-5. Add Tauri capability gates for enhanced mode.
+1. Keep WebRTC sender tuning stable (Opus preference + bitrate caps).
+2. Add adaptive quality ladder (resolution/fps/bitrate).
+3. Integrate external SRT gateway worker implementation against the control-plane contract.
+4. Wire metrics export into dashboards/alerts + incident runbooks.
+5. Harden Tauri packaging/signing and release distribution.
 
 ## Non-Goals
 - Replacing browser WebRTC call transport with direct SRT.

--- a/backend/src/api/mediaRoutes.ts
+++ b/backend/src/api/mediaRoutes.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http';
+import { mediaGatewayRepository, type GatewayReadinessState } from '../db/repositories/mediaGatewayRepository.js';
 
 function boolFromEnv(value: string | undefined, fallback: boolean = false): boolean {
 	if (value == null) return fallback;
@@ -11,17 +12,6 @@ function numberFromEnv(value: string | undefined, fallback: number): number {
 	return Number.isFinite(parsed) ? parsed : fallback;
 }
 
-interface GatewayHeartbeatState {
-	lastSeenAt: number;
-	version?: string;
-	region?: string;
-	activeStreams?: number;
-}
-
-const gatewayHeartbeat: GatewayHeartbeatState = {
-	lastSeenAt: 0
-};
-
 function isGatewayAuthorized(req: IncomingMessage): boolean {
 	const configuredKey = process.env.MEDIA_GATEWAY_KEY;
 	if (!configuredKey) return false;
@@ -29,16 +19,94 @@ function isGatewayAuthorized(req: IncomingMessage): boolean {
 	return typeof provided === 'string' && provided === configuredKey;
 }
 
+function parseReadinessState(value: unknown): GatewayReadinessState {
+	if (value === 'starting' || value === 'ready' || value === 'degraded' || value === 'draining' || value === 'offline') {
+		return value;
+	}
+	return 'starting';
+}
+
+async function parseBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+	let body = '';
+	await new Promise<void>((resolve, reject) => {
+		req.on('data', chunk => {
+			body += chunk.toString();
+		});
+		req.on('end', () => resolve());
+		req.on('error', reject);
+	});
+
+	if (!body) return {};
+	try {
+		return JSON.parse(body);
+	} catch {
+		throw new Error('Invalid JSON payload');
+	}
+}
+
+function writeJson(res: ServerResponse, status: number, body: Record<string, unknown>): void {
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(body));
+}
+
+interface StreamAccessRule {
+	tenantId: string;
+	workspaceIds: string[];
+	channelIds: string[];
+}
+
+function parseStreamAccessRules(): Record<string, StreamAccessRule> {
+	const raw = process.env.MEDIA_STREAM_ACCESS_RULES;
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw) as Record<string, Partial<StreamAccessRule>>;
+		const normalized: Record<string, StreamAccessRule> = {};
+		for (const [token, rule] of Object.entries(parsed)) {
+			normalized[token] = {
+				tenantId: typeof rule.tenantId === 'string' && rule.tenantId ? rule.tenantId : 'default',
+				workspaceIds: Array.isArray(rule.workspaceIds) ? rule.workspaceIds.filter((item): item is string => typeof item === 'string') : ['*'],
+				channelIds: Array.isArray(rule.channelIds) ? rule.channelIds.filter((item): item is string => typeof item === 'string') : ['*']
+			};
+		}
+		return normalized;
+	} catch (error) {
+		console.error('[MediaGateway] MEDIA_STREAM_ACCESS_RULES is invalid JSON:', error);
+		return {};
+	}
+}
+
+function authorizeStreamToken(req: IncomingMessage, workspaceId: string, channelId: string): { ok: true; tenantId: string; tokenId: string } | { ok: false; error: string } {
+	const token = req.headers['x-media-stream-token'];
+	if (typeof token !== 'string' || !token) {
+		return { ok: false, error: 'Missing stream token' };
+	}
+
+	const rules = parseStreamAccessRules();
+	const rule = rules[token];
+	if (!rule) {
+		return { ok: false, error: 'Invalid stream token' };
+	}
+
+	const workspaceAllowed = rule.workspaceIds.includes('*') || rule.workspaceIds.includes(workspaceId);
+	const channelAllowed = rule.channelIds.includes('*') || rule.channelIds.includes(channelId);
+	if (!workspaceAllowed || !channelAllowed) {
+		return { ok: false, error: 'Token is not authorized for workspace/channel scope' };
+	}
+
+	return { ok: true, tenantId: rule.tenantId, tokenId: token.slice(0, 8) };
+}
 
 // GET /api/media/runtime
-// Provides server runtime hints for media quality transport paths.
-export async function handleGetMediaRuntime(req: IncomingMessage, res: ServerResponse): Promise<void> {
+export async function handleGetMediaRuntime(_req: IncomingMessage, res: ServerResponse): Promise<void> {
 	try {
 		const srtGatewayEnabled = boolFromEnv(process.env.MEDIA_SRT_GATEWAY_ENABLED, false);
 		const localEnhancedEnabled = boolFromEnv(process.env.MEDIA_LOCAL_ENHANCED_ENABLED, true);
+		const heartbeatTimeoutMs = numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000);
+		const runtime = mediaGatewayRepository.getRuntimeRecord();
+		const now = Date.now();
+		const healthy = Boolean(runtime && now - runtime.last_seen_at < heartbeatTimeoutMs && runtime.readiness_state !== 'offline');
 
-		res.writeHead(200, { 'Content-Type': 'application/json' });
-		res.end(JSON.stringify({
+		writeJson(res, 200, {
 			media: {
 				localEnhancedEnabled,
 				srtGatewayEnabled,
@@ -49,61 +117,200 @@ export async function handleGetMediaRuntime(req: IncomingMessage, res: ServerRes
 				},
 				gateway: {
 					configured: Boolean(process.env.MEDIA_SRT_GATEWAY_URL),
-					heartbeatTimeoutMs: numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000),
-					healthy: gatewayHeartbeat.lastSeenAt > 0 && Date.now() - gatewayHeartbeat.lastSeenAt < numberFromEnv(process.env.MEDIA_GATEWAY_HEARTBEAT_TIMEOUT_MS, 45_000),
-					lastSeenAt: gatewayHeartbeat.lastSeenAt || null,
-					activeStreams: gatewayHeartbeat.activeStreams ?? 0,
-					version: gatewayHeartbeat.version || null,
-					region: gatewayHeartbeat.region || null
+					heartbeatTimeoutMs,
+					healthy,
+					status: runtime?.status ?? 'offline',
+					readinessState: runtime?.readiness_state ?? 'offline',
+					lastSeenAt: runtime?.last_seen_at ?? null,
+					activeStreams: runtime?.active_streams ?? 0,
+					version: runtime?.version ?? null,
+					region: runtime?.region ?? null,
+					instanceId: runtime?.instance_id ?? null,
+					activeLeases: mediaGatewayRepository.countActiveLeases(now)
 				}
 			},
 			notes: {
 				srtDirectBrowserSupported: false,
 				message: 'SRT is expected to run through a server-side media gateway, not directly from browser WebRTC peers.'
 			}
-		}));
+		});
 	} catch (error) {
 		console.error('[MediaRuntime] Failed to return media runtime config:', error);
-		res.writeHead(500, { 'Content-Type': 'application/json' });
-		res.end(JSON.stringify({ error: 'Failed to read media runtime configuration' }));
+		writeJson(res, 500, { error: 'Failed to read media runtime configuration' });
 	}
 }
 
-
-// POST /api/media/gateway-heartbeat
-// Optional SRT gateway can report health/stream load to backend.
-export async function handleMediaGatewayHeartbeat(req: IncomingMessage, res: ServerResponse): Promise<void> {
+// POST /api/media/gateway/register
+export async function handleMediaGatewayRegister(req: IncomingMessage, res: ServerResponse): Promise<void> {
 	if (!isGatewayAuthorized(req)) {
-		res.writeHead(401, { 'Content-Type': 'application/json' });
-		res.end(JSON.stringify({ error: 'Unauthorized gateway heartbeat' }));
+		writeJson(res, 401, { error: 'Unauthorized gateway register' });
 		return;
 	}
 
-	let body = '';
-	await new Promise<void>((resolve, reject) => {
-		req.on('data', chunk => {
-			body += chunk.toString();
+	try {
+		const payload = await parseBody(req);
+		const instanceId = typeof payload.instanceId === 'string' ? payload.instanceId : undefined;
+		const runtime = mediaGatewayRepository.upsertRuntime({
+			instanceId,
+			status: typeof payload.status === 'string' ? payload.status : 'online',
+			readinessState: parseReadinessState(payload.readinessState),
+			version: typeof payload.version === 'string' ? payload.version : undefined,
+			region: typeof payload.region === 'string' ? payload.region : undefined,
+			activeStreams: typeof payload.activeStreams === 'number' ? payload.activeStreams : undefined,
+			lastSeenAt: Date.now()
 		});
-		req.on('end', () => resolve());
-		req.on('error', reject);
-	});
 
-	let payload: Record<string, unknown> = {};
-	if (body) {
-		try {
-			payload = JSON.parse(body);
-		} catch {
-			res.writeHead(400, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ error: 'Invalid JSON in gateway heartbeat' }));
-			return;
-		}
+		mediaGatewayRepository.audit({
+			actorType: 'gateway',
+			actorId: instanceId ?? 'unknown',
+			action: 'gateway.register',
+			metadata: { readinessState: runtime.readiness_state }
+		});
+
+		writeJson(res, 200, { ok: true, runtime });
+	} catch (error) {
+		writeJson(res, 400, { error: error instanceof Error ? error.message : 'Invalid payload' });
+	}
+}
+
+// POST /api/media/gateway-heartbeat
+export async function handleMediaGatewayHeartbeat(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		writeJson(res, 401, { error: 'Unauthorized gateway heartbeat' });
+		return;
 	}
 
-	gatewayHeartbeat.lastSeenAt = Date.now();
-	gatewayHeartbeat.version = typeof payload.version === 'string' ? payload.version : undefined;
-	gatewayHeartbeat.region = typeof payload.region === 'string' ? payload.region : undefined;
-	gatewayHeartbeat.activeStreams = typeof payload.activeStreams === 'number' ? payload.activeStreams : 0;
+	try {
+		const payload = await parseBody(req);
+		mediaGatewayRepository.upsertRuntime({
+			instanceId: typeof payload.instanceId === 'string' ? payload.instanceId : undefined,
+			status: 'online',
+			readinessState: parseReadinessState(payload.readinessState === undefined ? 'ready' : payload.readinessState),
+			version: typeof payload.version === 'string' ? payload.version : undefined,
+			region: typeof payload.region === 'string' ? payload.region : undefined,
+			activeStreams: typeof payload.activeStreams === 'number' ? payload.activeStreams : undefined,
+			lastSeenAt: Date.now()
+		});
+		writeJson(res, 200, { ok: true });
+	} catch (error) {
+		writeJson(res, 400, { error: error instanceof Error ? error.message : 'Invalid payload' });
+	}
+}
 
-	res.writeHead(200, { 'Content-Type': 'application/json' });
-	res.end(JSON.stringify({ ok: true }));
+// POST /api/media/gateway/streams/claim
+export async function handleMediaGatewayStreamClaim(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		writeJson(res, 401, { error: 'Unauthorized gateway request' });
+		return;
+	}
+
+	try {
+		const payload = await parseBody(req);
+		const streamId = typeof payload.streamId === 'string' ? payload.streamId : '';
+		const workspaceId = typeof payload.workspaceId === 'string' ? payload.workspaceId : '';
+		const channelId = typeof payload.channelId === 'string' ? payload.channelId : '';
+		const ownerInstance = typeof payload.ownerInstance === 'string' && payload.ownerInstance ? payload.ownerInstance : 'gateway';
+		const leaseTtlMsRaw = typeof payload.leaseTtlMs === 'number' ? payload.leaseTtlMs : 60_000;
+		const leaseTtlMs = Math.max(10_000, Math.min(leaseTtlMsRaw, 300_000));
+
+		if (!streamId || !workspaceId || !channelId) {
+			writeJson(res, 400, { error: 'streamId, workspaceId, and channelId are required' });
+			return;
+		}
+
+		const authz = authorizeStreamToken(req, workspaceId, channelId);
+		if (!authz.ok) {
+			writeJson(res, 403, { error: authz.error });
+			return;
+		}
+
+		const result = mediaGatewayRepository.claimLease({
+			streamId,
+			tenantId: authz.tenantId,
+			workspaceId,
+			channelId,
+			ownerInstance,
+			leaseTtlMs
+		});
+
+		if (!result.granted || !result.lease) {
+			mediaGatewayRepository.audit({
+				actorType: 'gateway',
+				actorId: ownerInstance,
+				action: 'stream.claim.denied',
+				streamId,
+				workspaceId,
+				channelId,
+				metadata: { reason: 'lease_conflict', conflictOwner: result.conflict?.owner_instance }
+			});
+			writeJson(res, 409, {
+				error: 'Stream already leased',
+				conflict: {
+					ownerInstance: result.conflict?.owner_instance,
+					leaseExpiresAt: result.conflict?.lease_expires_at ?? null
+				}
+			});
+			return;
+		}
+
+		mediaGatewayRepository.audit({
+			actorType: 'gateway',
+			actorId: ownerInstance,
+			action: 'stream.claim.granted',
+			streamId,
+			workspaceId,
+			channelId,
+			metadata: { tokenId: authz.tokenId, leaseTtlMs }
+		});
+
+		writeJson(res, 200, {
+			ok: true,
+			lease: {
+				streamId: result.lease.stream_id,
+				leaseToken: result.lease.lease_token,
+				leaseExpiresAt: result.lease.lease_expires_at,
+				tenantId: result.lease.tenant_id,
+				ownerInstance: result.lease.owner_instance
+			}
+		});
+	} catch (error) {
+		writeJson(res, 400, { error: error instanceof Error ? error.message : 'Invalid payload' });
+	}
+}
+
+// POST /api/media/gateway/streams/release
+export async function handleMediaGatewayStreamRelease(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	if (!isGatewayAuthorized(req)) {
+		writeJson(res, 401, { error: 'Unauthorized gateway request' });
+		return;
+	}
+
+	try {
+		const payload = await parseBody(req);
+		const streamId = typeof payload.streamId === 'string' ? payload.streamId : '';
+		const leaseToken = typeof payload.leaseToken === 'string' ? payload.leaseToken : '';
+		const ownerInstance = typeof payload.ownerInstance === 'string' && payload.ownerInstance ? payload.ownerInstance : 'gateway';
+		if (!streamId || !leaseToken) {
+			writeJson(res, 400, { error: 'streamId and leaseToken are required' });
+			return;
+		}
+
+		const released = mediaGatewayRepository.releaseLease(streamId, leaseToken);
+		mediaGatewayRepository.audit({
+			actorType: 'gateway',
+			actorId: ownerInstance,
+			action: released ? 'stream.release.success' : 'stream.release.miss',
+			streamId,
+			metadata: { providedLeaseTokenPrefix: leaseToken.slice(0, 8) }
+		});
+
+		if (!released) {
+			writeJson(res, 404, { error: 'Active lease not found for stream/token combination' });
+			return;
+		}
+
+		writeJson(res, 200, { ok: true });
+	} catch (error) {
+		writeJson(res, 400, { error: error instanceof Error ? error.message : 'Invalid payload' });
+	}
 }

--- a/backend/src/db/repositories/mediaGatewayRepository.ts
+++ b/backend/src/db/repositories/mediaGatewayRepository.ts
@@ -1,0 +1,177 @@
+import crypto from 'crypto';
+import db from '../database.js';
+
+export type GatewayReadinessState = 'starting' | 'ready' | 'degraded' | 'draining' | 'offline';
+
+export interface GatewayRuntimeRecord {
+	gateway_id: string;
+	instance_id: string | null;
+	status: string;
+	readiness_state: GatewayReadinessState;
+	version: string | null;
+	region: string | null;
+	active_streams: number;
+	last_seen_at: number;
+	updated_at: number;
+}
+
+export interface StreamLeaseRecord {
+	stream_id: string;
+	tenant_id: string;
+	workspace_id: string;
+	channel_id: string;
+	owner_instance: string;
+	lease_token: string;
+	lease_expires_at: number;
+	status: string;
+	updated_at: number;
+}
+
+export class MediaGatewayRepository {
+	upsertRuntime(input: {
+		instanceId?: string;
+		status?: string;
+		readinessState?: GatewayReadinessState;
+		version?: string;
+		region?: string;
+		activeStreams?: number;
+		lastSeenAt?: number;
+	}): GatewayRuntimeRecord {
+		const now = Date.now();
+		const runtime = this.getRuntimeRecord();
+		const merged = {
+			gatewayId: 'primary',
+			instanceId: input.instanceId ?? runtime?.instance_id ?? null,
+			status: input.status ?? runtime?.status ?? 'online',
+			readinessState: input.readinessState ?? runtime?.readiness_state ?? 'starting',
+			version: input.version ?? runtime?.version ?? null,
+			region: input.region ?? runtime?.region ?? null,
+			activeStreams: input.activeStreams ?? runtime?.active_streams ?? 0,
+			lastSeenAt: input.lastSeenAt ?? now,
+			updatedAt: now
+		};
+
+		db.prepare(`
+			INSERT INTO media_gateway_runtime (gateway_id, instance_id, status, readiness_state, version, region, active_streams, last_seen_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(gateway_id) DO UPDATE SET
+				instance_id = excluded.instance_id,
+				status = excluded.status,
+				readiness_state = excluded.readiness_state,
+				version = excluded.version,
+				region = excluded.region,
+				active_streams = excluded.active_streams,
+				last_seen_at = excluded.last_seen_at,
+				updated_at = excluded.updated_at
+		`).run(
+			merged.gatewayId,
+			merged.instanceId,
+			merged.status,
+			merged.readinessState,
+			merged.version,
+			merged.region,
+			merged.activeStreams,
+			merged.lastSeenAt,
+			merged.updatedAt
+		);
+
+		return this.getRuntimeRecord() as GatewayRuntimeRecord;
+	}
+
+	getRuntimeRecord(): GatewayRuntimeRecord | null {
+		return (db.prepare('SELECT * FROM media_gateway_runtime WHERE gateway_id = ?').get('primary') as GatewayRuntimeRecord) ?? null;
+	}
+
+	claimLease(input: {
+		streamId: string;
+		tenantId: string;
+		workspaceId: string;
+		channelId: string;
+		ownerInstance: string;
+		leaseTtlMs: number;
+	}): { granted: boolean; lease?: StreamLeaseRecord; conflict?: StreamLeaseRecord } {
+		const now = Date.now();
+		const leaseExpiresAt = now + input.leaseTtlMs;
+		const nextToken = crypto.randomBytes(18).toString('hex');
+
+		const txn = db.transaction(() => {
+			const existing = db.prepare('SELECT * FROM media_gateway_stream_leases WHERE stream_id = ?').get(input.streamId) as StreamLeaseRecord | undefined;
+			if (existing && existing.lease_expires_at > now && existing.status === 'active') {
+				return { granted: false as const, conflict: existing };
+			}
+
+			db.prepare(`
+				INSERT INTO media_gateway_stream_leases (stream_id, tenant_id, workspace_id, channel_id, owner_instance, lease_token, lease_expires_at, status, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?)
+				ON CONFLICT(stream_id) DO UPDATE SET
+					tenant_id = excluded.tenant_id,
+					workspace_id = excluded.workspace_id,
+					channel_id = excluded.channel_id,
+					owner_instance = excluded.owner_instance,
+					lease_token = excluded.lease_token,
+					lease_expires_at = excluded.lease_expires_at,
+					status = excluded.status,
+					updated_at = excluded.updated_at
+			`).run(
+				input.streamId,
+				input.tenantId,
+				input.workspaceId,
+				input.channelId,
+				input.ownerInstance,
+				nextToken,
+				leaseExpiresAt,
+				now
+			);
+
+			const lease = db.prepare('SELECT * FROM media_gateway_stream_leases WHERE stream_id = ?').get(input.streamId) as StreamLeaseRecord;
+			return { granted: true as const, lease };
+		});
+
+		return txn();
+	}
+
+	releaseLease(streamId: string, leaseToken: string): boolean {
+		const now = Date.now();
+		const result = db.prepare(`
+			UPDATE media_gateway_stream_leases
+			SET status = 'released', updated_at = ?, lease_expires_at = ?
+			WHERE stream_id = ? AND lease_token = ?
+		`).run(now, now, streamId, leaseToken);
+		return result.changes > 0;
+	}
+
+	countActiveLeases(now: number = Date.now()): number {
+		const row = db.prepare(`
+			SELECT COUNT(*) as total
+			FROM media_gateway_stream_leases
+			WHERE status = 'active' AND lease_expires_at > ?
+		`).get(now) as { total: number };
+		return row.total;
+	}
+
+	audit(input: {
+		actorType: string;
+		actorId: string;
+		action: string;
+		streamId?: string;
+		workspaceId?: string;
+		channelId?: string;
+		metadata?: Record<string, unknown>;
+	}): void {
+		db.prepare(`
+			INSERT INTO media_gateway_audit_log (actor_type, actor_id, action, stream_id, workspace_id, channel_id, metadata_json, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`).run(
+			input.actorType,
+			input.actorId,
+			input.action,
+			input.streamId ?? null,
+			input.workspaceId ?? null,
+			input.channelId ?? null,
+			JSON.stringify(input.metadata ?? {}),
+			Date.now()
+		);
+	}
+}
+
+export const mediaGatewayRepository = new MediaGatewayRepository();

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -251,3 +251,45 @@ CREATE INDEX IF NOT EXISTS idx_webhooks_user ON webhooks(user_id);
 CREATE INDEX IF NOT EXISTS idx_webhooks_enabled ON webhooks(enabled);
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook ON webhook_deliveries(webhook_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries(status, updated_at);
+
+-- Media gateway control-plane runtime and durable stream lease state
+CREATE TABLE IF NOT EXISTS media_gateway_runtime (
+  gateway_id TEXT PRIMARY KEY,
+  instance_id TEXT,
+  status TEXT NOT NULL DEFAULT 'online',
+  readiness_state TEXT NOT NULL DEFAULT 'starting',
+  version TEXT,
+  region TEXT,
+  active_streams INTEGER NOT NULL DEFAULT 0,
+  last_seen_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS media_gateway_stream_leases (
+  stream_id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  owner_instance TEXT NOT NULL,
+  lease_token TEXT NOT NULL,
+  lease_expires_at INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS media_gateway_audit_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_type TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  stream_id TEXT,
+  workspace_id TEXT,
+  channel_id TEXT,
+  metadata_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_media_gateway_stream_leases_expires
+  ON media_gateway_stream_leases(status, lease_expires_at);
+CREATE INDEX IF NOT EXISTS idx_media_gateway_audit_created
+  ON media_gateway_audit_log(created_at DESC);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,7 +17,7 @@ import { verifyToken } from "./auth/jwt.js";
 import { handleRegister, handleLogin, handleUpgrade, handleGetUserSettings, handleSaveUserSettings, handleGetPublicKey, handleStoreEncryptionKeys } from "./api/authRoutes.js";
 import { handleGetThemePreferences, handleSaveThemePreferences, handleResetThemePreferences } from "./api/themeRoutes.js";
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
-import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
+import { handleGetMediaRuntime, handleMediaGatewayHeartbeat, handleMediaGatewayRegister, handleMediaGatewayStreamClaim, handleMediaGatewayStreamRelease } from "./api/mediaRoutes.js";
 import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handleListWebhookDeliveries } from "./api/webhookRoutes.js";
 import { relayRepository } from "./db/repositories/relayRepository.js";
 import { corsCallback, getCORSHeaders, getAllowedOrigins, isOriginAllowed } from "./config/cors.js";
@@ -1003,8 +1003,23 @@ server.on('request', async (req, res) => {
     return;
   }
 
+  if (url.pathname === "/api/media/gateway/register" && req.method === "POST") {
+    await handleMediaGatewayRegister(req, res);
+    return;
+  }
+
   if (url.pathname === "/api/media/gateway-heartbeat" && req.method === "POST") {
     await handleMediaGatewayHeartbeat(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/gateway/streams/claim" && req.method === "POST") {
+    await handleMediaGatewayStreamClaim(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/media/gateway/streams/release" && req.method === "POST") {
+    await handleMediaGatewayStreamRelease(req, res);
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Provide a proper control-plane boundary for server-side media gateways so SRT/ingest logic is not managed ad-hoc from API handlers and so gateway lifecycle can be reconciled with the backend.
- Persist gateway runtime and stream ownership state so leases, readiness, and audit trails survive process restarts and are safe under single-database concurrency.
- Enforce per-stream ACLs scoped to tenant/workspace/channel to prevent unscoped token allowlists from granting unintended access.

### Description
- Introduces a new repository `backend/src/db/repositories/mediaGatewayRepository.ts` that implements runtime upsert, transactional conflict-safe stream lease `claimLease`/`releaseLease`, active-lease counting, and an `audit` logger.
- Extends the SQLite schema in `backend/src/db/schema.sql` with `media_gateway_runtime`, `media_gateway_stream_leases`, and `media_gateway_audit_log` tables and supporting indexes.
- Reworks media API surface in `backend/src/api/mediaRoutes.ts` to add control-plane endpoints and helpers: `POST /api/media/gateway/register` (`handleMediaGatewayRegister`), `POST /api/media/gateway-heartbeat` (`handleMediaGatewayHeartbeat`), `POST /api/media/gateway/streams/claim` (`handleMediaGatewayStreamClaim`), and `POST /api/media/gateway/streams/release` (`handleMediaGatewayStreamRelease`), and to read durable runtime state from the repository for `GET /api/media/runtime` (`handleGetMediaRuntime`).
- Adds scoped stream-token ACL parsing via the `MEDIA_STREAM_ACCESS_RULES` env var and enforces token/workspace/channel authorization before granting leases, and emits audit entries on register/claim/release events.
- Wires the new endpoints into the HTTP router in `backend/src/server.ts` and updates project docs `PROJECT_DOCS/CALLING_TRANSPORT_ARCHITECTURE.md` to describe the control-plane contract and env config.

### Testing
- Built the backend bundle with `cd backend && npm run build` which completed successfully and produced `dist/server.js` (esbuild output shown), indicating TypeScript/Esm bundling succeeded.
- No runtime integration tests were added in this change; database migrations are created in `schema.sql` so existing CI that runs the build should catch syntax/type regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991eb01ad90832abd785b7acf3a4173)