### PR TITLE
Add frontend plugin runtime with extension hosts and admin controls

### DIFF
--- a/frontend/src/lib/components/MainLayout.svelte
+++ b/frontend/src/lib/components/MainLayout.svelte
@@ -9,6 +9,7 @@
 	import CallModal from '$lib/components/CallModal.svelte';
 	import AuthErrorBanner from '$lib/components/AuthErrorBanner.svelte';
 	import { channelMessages, channelUnreadCounts, channels, currentUser, users, type Channel, type User } from '$lib/socket';
+	import PluginSlot from '$lib/components/plugins/PluginSlot.svelte';
 
 	export let activeView: 'chat' | 'screen' = 'chat';
 
@@ -130,6 +131,9 @@
 		class:mobile-visible={$layoutStore.showMobileChannels}
 	>
 		<ChannelSidebar on:close={() => layoutStore.showMobileChannels.set(false)} bind:activeView on:logout />
+		<div class="plugin-sidebar-slot">
+			<PluginSlot point="sidebar" />
+		</div>
 		<!-- Channel resize handle -->
 		<div
 			class="resize-handle resize-handle-channel"
@@ -147,6 +151,9 @@
 	<!-- Main Content -->
 	<div class="main-content">
 		<div class:hidden={activeView !== 'chat'}><Chat on:logout /></div>
+		<div class="plugin-channel-slot">
+			<PluginSlot point="channelViews" />
+		</div>
 		<div class:hidden={activeView !== 'screen'}><ScreenShareViewer bind:activeView /></div>
 	</div>
 
@@ -256,6 +263,19 @@
 		border-right: none;
 	}
 
+
+	.plugin-sidebar-slot {
+		padding: 0.5rem;
+		border-top: 1px solid rgba(var(--border-rgb), var(--opacity-light));
+	}
+
+	.plugin-channel-slot {
+		position: absolute;
+		right: 0.5rem;
+		top: 0.5rem;
+		z-index: 8;
+		max-width: 320px;
+	}
 	/* Desktop Right Panel */
 	.right-panel-container {
 		flex-shrink: 0;

--- a/frontend/src/lib/components/plugins/PluginSlot.svelte
+++ b/frontend/src/lib/components/plugins/PluginSlot.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { channels, currentChannel } from '$lib/socket';
+	import { pluginRegistry } from '$lib/plugins/registry';
+
+	export let point: 'sidebar' | 'commands' | 'channelViews' = 'sidebar';
+
+	let extensions: Array<{ pluginId: string; pluginName: string; extension: { component: any }; loadError?: string }> = [];
+
+	$: activeChannelType = $channels.find((channel) => channel.id === $currentChannel)?.type;
+
+	$: if (point === 'sidebar') {
+		extensions = pluginRegistry.resolveSidebarExtensions();
+	} else if (point === 'channelViews') {
+		extensions = pluginRegistry.resolveChannelViews(activeChannelType);
+	} else {
+		extensions = [];
+	}
+
+	onMount(() => {
+		void pluginRegistry.hydrateFromServer();
+	});
+</script>
+
+{#if point === 'commands'}
+	<!-- commands are resolved by consumers through pluginRegistry.resolveCommandExtensions() -->
+{:else}
+	<div class="plugin-slot plugin-slot-{point}">
+		{#each extensions as extension (extension.pluginId)}
+			{#if extension.loadError}
+				<div class="plugin-fallback" role="status">
+					<strong>{extension.pluginName}</strong>
+					<span>Failed to load extension.</span>
+				</div>
+			{:else if extension.extension?.component}
+				<svelte:component
+					this={extension.extension.component}
+					pluginId={extension.pluginId}
+					pluginName={extension.pluginName}
+					channelType={activeChannelType}
+				/>
+			{/if}
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.plugin-slot {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.plugin-fallback {
+		display: flex;
+		flex-direction: column;
+		padding: 0.5rem;
+		border: 1px solid rgba(var(--border-rgb), var(--opacity-light));
+		border-radius: 0.5rem;
+		background: rgba(var(--bg-secondary-rgb), 0.55);
+		font-size: 0.8rem;
+	}
+</style>

--- a/frontend/src/lib/plugins/api.ts
+++ b/frontend/src/lib/plugins/api.ts
@@ -1,0 +1,64 @@
+import { browser } from '$app/environment';
+import { getServerUrl } from '$lib/serverUrl';
+import type { PluginListItem } from './manifest';
+
+const baseUrl = getServerUrl();
+
+function buildHeaders(): HeadersInit {
+	const headers: HeadersInit = { 'Content-Type': 'application/json' };
+	if (!browser) return headers;
+
+	const token = localStorage.getItem('authToken');
+	if (token) {
+		headers.Authorization = `Bearer ${token}`;
+	}
+	return headers;
+}
+
+async function parseResponse<T>(res: Response, fallbackMessage: string): Promise<T> {
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(body || fallbackMessage);
+	}
+	return res.json() as Promise<T>;
+}
+
+export async function fetchPlugins(): Promise<PluginListItem[]> {
+	const res = await fetch(`${baseUrl}/api/plugins`, {
+		method: 'GET',
+		headers: buildHeaders()
+	});
+
+	const payload = await parseResponse<{ plugins: PluginListItem[] } | PluginListItem[]>(
+		res,
+		'Failed to fetch plugins'
+	);
+
+	if (Array.isArray(payload)) return payload;
+	return payload.plugins;
+}
+
+export async function setPluginEnabled(pluginId: string, enabled: boolean): Promise<void> {
+	const endpoint = enabled ? 'enable' : 'disable';
+	const res = await fetch(`${baseUrl}/api/plugins/${encodeURIComponent(pluginId)}/${endpoint}`, {
+		method: 'POST',
+		headers: buildHeaders()
+	});
+
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(body || `Failed to ${endpoint} plugin`);
+	}
+}
+
+export async function requestPluginReload(pluginId: string): Promise<void> {
+	const res = await fetch(`${baseUrl}/api/plugins/${encodeURIComponent(pluginId)}/reload`, {
+		method: 'POST',
+		headers: buildHeaders()
+	});
+
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(body || 'Failed to reload plugin');
+	}
+}

--- a/frontend/src/lib/plugins/manifest.ts
+++ b/frontend/src/lib/plugins/manifest.ts
@@ -1,0 +1,71 @@
+export type PluginStatus = 'enabled' | 'disabled' | 'error' | 'loading';
+
+export interface PluginSidebarExtensionManifest {
+	icon: string;
+	label: string;
+	component: string;
+	position?: number;
+}
+
+export interface PluginFrontendExtensionsManifest {
+	sidebar?: PluginSidebarExtensionManifest;
+	commands?: string[];
+	channelTypes?: string[];
+}
+
+export interface PluginFrontendManifest {
+	entry: string;
+	extensions?: PluginFrontendExtensionsManifest;
+}
+
+export interface PluginManifest {
+	id: string;
+	name: string;
+	version: string;
+	description: string;
+	author: string;
+	enabled?: boolean;
+	frontend?: PluginFrontendManifest;
+	permissions?: string[];
+	dependencies?: string[];
+}
+
+export interface PluginListItem {
+	id: string;
+	manifest: PluginManifest;
+}
+
+export interface PluginExtensionComponentProps {
+	pluginId: string;
+	pluginName: string;
+	channelType?: string;
+}
+
+export interface PluginCommandExtension {
+	id: string;
+	label: string;
+	description?: string;
+	execute: (...args: unknown[]) => void | Promise<void>;
+}
+
+export interface PluginChannelViewExtension {
+	id: string;
+	channelType: string;
+	component: unknown;
+}
+
+export interface PluginFrontendRuntimeModule {
+	sidebar?: {
+		component: unknown;
+	};
+	commands?: PluginCommandExtension[];
+	channelViews?: PluginChannelViewExtension[];
+}
+
+export interface ResolvedPluginExtension<T = unknown> {
+	pluginId: string;
+	pluginName: string;
+	position: number;
+	extension: T;
+	loadError?: string;
+}

--- a/frontend/src/lib/plugins/registry.ts
+++ b/frontend/src/lib/plugins/registry.ts
@@ -1,0 +1,269 @@
+import { browser } from '$app/environment';
+import { derived, get, writable } from 'svelte/store';
+import { fetchPlugins, requestPluginReload, setPluginEnabled } from './api';
+import type {
+	PluginCommandExtension,
+	PluginFrontendRuntimeModule,
+	PluginListItem,
+	PluginManifest,
+	PluginStatus,
+	ResolvedPluginExtension
+} from './manifest';
+
+export interface RegisteredPlugin {
+	id: string;
+	manifest: PluginManifest;
+	enabled: boolean;
+	status: PluginStatus;
+	module?: PluginFrontendRuntimeModule;
+	loadError?: string;
+	lastLoadedAt?: number;
+}
+
+interface PluginRegistryState {
+	plugins: Record<string, RegisteredPlugin>;
+	loading: boolean;
+	error?: string;
+}
+
+const initialState: PluginRegistryState = {
+	plugins: {},
+	loading: false
+};
+
+const state = writable<PluginRegistryState>(initialState);
+
+async function loadFrontendModule(plugin: RegisteredPlugin): Promise<RegisteredPlugin> {
+	if (!browser || !plugin.enabled || !plugin.manifest.frontend?.entry) {
+		return plugin;
+	}
+
+	try {
+		const imported = (await import(/* @vite-ignore */ plugin.manifest.frontend.entry)) as
+			| PluginFrontendRuntimeModule
+			| { default?: PluginFrontendRuntimeModule };
+		const module = ('default' in imported && imported.default ? imported.default : imported) as PluginFrontendRuntimeModule;
+		return {
+			...plugin,
+			status: 'enabled',
+			module,
+			loadError: undefined,
+			lastLoadedAt: Date.now()
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Unknown module load error';
+		return {
+			...plugin,
+			status: 'error',
+			module: undefined,
+			loadError: message
+		};
+	}
+}
+
+function buildRegisteredPlugin(item: PluginListItem): RegisteredPlugin {
+	return {
+		id: item.id,
+		manifest: item.manifest,
+		enabled: item.manifest.enabled ?? true,
+		status: item.manifest.enabled === false ? 'disabled' : 'loading'
+	};
+}
+
+export const pluginRegistry = {
+	subscribe: state.subscribe,
+
+	plugins: derived(state, ($state) => Object.values($state.plugins)),
+
+	async hydrateFromServer() {
+		const snapshot = getState();
+		if (snapshot.loading || Object.keys(snapshot.plugins).length > 0) return;
+
+		state.update((current) => ({ ...current, loading: true, error: undefined }));
+		try {
+			const plugins = await fetchPlugins();
+			for (const plugin of plugins) {
+				await this.registerPlugin(plugin);
+			}
+			state.update((current) => ({ ...current, loading: false }));
+		} catch (error) {
+			state.update((current) => ({
+				...current,
+				loading: false,
+				error: error instanceof Error ? error.message : 'Failed to hydrate plugins'
+			}));
+		}
+	},
+
+	async registerPlugin(item: PluginListItem) {
+		let plugin = buildRegisteredPlugin(item);
+		plugin = await loadFrontendModule(plugin);
+		state.update((current) => ({
+			...current,
+			plugins: {
+				...current.plugins,
+				[plugin.id]: plugin
+			}
+		}));
+	},
+
+	unregisterPlugin(pluginId: string) {
+		state.update((current) => {
+			const next = { ...current.plugins };
+			delete next[pluginId];
+			return { ...current, plugins: next };
+		});
+	},
+
+	async enablePlugin(pluginId: string) {
+		const current = getPlugin(pluginId);
+		if (!current) return;
+
+		state.update((s) => ({
+			...s,
+			plugins: {
+				...s.plugins,
+				[pluginId]: { ...current, enabled: true, status: 'loading' }
+			}
+		}));
+
+		try {
+			await setPluginEnabled(pluginId, true);
+			const loaded = await loadFrontendModule({ ...current, enabled: true });
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: loaded
+				}
+			}));
+		} catch (error) {
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: {
+						...current,
+						loadError: error instanceof Error ? error.message : 'Failed to enable plugin',
+						status: 'error'
+					}
+				}
+			}));
+		}
+	},
+
+	async disablePlugin(pluginId: string) {
+		const current = getPlugin(pluginId);
+		if (!current) return;
+		try {
+			await setPluginEnabled(pluginId, false);
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: { ...current, enabled: false, status: 'disabled', module: undefined }
+				}
+			}));
+		} catch (error) {
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: {
+						...current,
+						loadError: error instanceof Error ? error.message : 'Failed to disable plugin',
+						status: 'error'
+					}
+				}
+			}));
+		}
+	},
+
+	async reloadPlugin(pluginId: string) {
+		const current = getPlugin(pluginId);
+		if (!current) return;
+
+		state.update((s) => ({
+			...s,
+			plugins: {
+				...s.plugins,
+				[pluginId]: { ...current, status: 'loading' }
+			}
+		}));
+
+		try {
+			await requestPluginReload(pluginId);
+			const loaded = await loadFrontendModule({ ...current, enabled: true });
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: loaded
+				}
+			}));
+		} catch (error) {
+			state.update((s) => ({
+				...s,
+				plugins: {
+					...s.plugins,
+					[pluginId]: {
+						...current,
+						status: 'error',
+						loadError: error instanceof Error ? error.message : 'Failed to reload plugin'
+					}
+				}
+			}));
+		}
+	},
+
+	resolveSidebarExtensions(): ResolvedPluginExtension<{ component: unknown }>[] {
+		const resolved = Object.values(getState().plugins)
+			.filter((plugin) => plugin.enabled && plugin.module?.sidebar)
+			.map((plugin) => ({
+				pluginId: plugin.id,
+				pluginName: plugin.manifest.name,
+				position: plugin.manifest.frontend?.extensions?.sidebar?.position ?? 100,
+				extension: { component: plugin.module?.sidebar?.component },
+				loadError: plugin.loadError
+			}));
+		return resolved.sort((a, b) => a.position - b.position);
+	},
+
+	resolveCommandExtensions(): ResolvedPluginExtension<PluginCommandExtension>[] {
+		return Object.values(getState().plugins)
+			.filter((plugin) => plugin.enabled && plugin.module?.commands?.length)
+			.flatMap((plugin) =>
+				(plugin.module?.commands || []).map((command) => ({
+					pluginId: plugin.id,
+					pluginName: plugin.manifest.name,
+					position: 100,
+					extension: command,
+					loadError: plugin.loadError
+				}))
+			);
+	},
+
+	resolveChannelViews(channelType?: string): ResolvedPluginExtension<{ component: unknown }>[] {
+		return Object.values(getState().plugins)
+			.filter((plugin) => plugin.enabled && plugin.module?.channelViews?.length)
+			.flatMap((plugin) =>
+				(plugin.module?.channelViews || [])
+					.filter((view) => !channelType || view.channelType === channelType)
+					.map((view) => ({
+						pluginId: plugin.id,
+						pluginName: plugin.manifest.name,
+						position: 100,
+						extension: { component: view.component },
+						loadError: plugin.loadError
+					}))
+			);
+	}
+};
+
+function getState(): PluginRegistryState {
+	return get(state);
+}
+
+function getPlugin(pluginId: string): RegisteredPlugin | undefined {
+	return getState().plugins[pluginId];
+}

--- a/frontend/src/routes/admin/plugins/+page.svelte
+++ b/frontend/src/routes/admin/plugins/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { pluginRegistry } from '$lib/plugins/registry';
+
+	let plugins: any[] = [];
+	let syncing: Record<string, boolean> = {};
+
+	const unsubscribe = pluginRegistry.plugins.subscribe((items) => {
+		plugins = items;
+	});
+
+	onMount(() => {
+		void pluginRegistry.hydrateFromServer();
+		return () => unsubscribe();
+	});
+
+	async function togglePlugin(pluginId: string, enabled: boolean) {
+		syncing = { ...syncing, [pluginId]: true };
+		if (enabled) {
+			await pluginRegistry.enablePlugin(pluginId);
+		} else {
+			await pluginRegistry.disablePlugin(pluginId);
+		}
+		syncing = { ...syncing, [pluginId]: false };
+	}
+
+	async function reloadPlugin(pluginId: string) {
+		syncing = { ...syncing, [pluginId]: true };
+		await pluginRegistry.reloadPlugin(pluginId);
+		syncing = { ...syncing, [pluginId]: false };
+	}
+</script>
+
+<section class="plugin-admin-page">
+	<header>
+		<h1>Plugin Controls</h1>
+		<p>Manage installed plugin status and request backend/frontend reloads.</p>
+	</header>
+
+	{#if plugins.length === 0}
+		<div class="empty-state">No plugins discovered from backend metadata.</div>
+	{:else}
+		<ul class="plugin-list">
+			{#each plugins as plugin (plugin.id)}
+				<li class="plugin-card">
+					<div class="plugin-meta">
+						<h2>{plugin.manifest.name}</h2>
+						<p>{plugin.manifest.description}</p>
+						<div class="details">
+							<span>v{plugin.manifest.version}</span>
+							<span>by {plugin.manifest.author}</span>
+							<span class="badge badge-{plugin.status}">{plugin.status}</span>
+						</div>
+						{#if plugin.loadError}
+							<div class="error">{plugin.loadError}</div>
+						{/if}
+					</div>
+					<div class="controls">
+						<button on:click={() => togglePlugin(plugin.id, !plugin.enabled)} disabled={!!syncing[plugin.id]}>
+							{plugin.enabled ? 'Disable' : 'Enable'}
+						</button>
+						<button on:click={() => reloadPlugin(plugin.id)} disabled={!!syncing[plugin.id]}>Reload</button>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>
+
+<style>
+	.plugin-admin-page {
+		max-width: 900px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+	.plugin-list {
+		list-style: none;
+		display: grid;
+		gap: 1rem;
+		padding: 0;
+	}
+	.plugin-card {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 1rem;
+		border: 1px solid rgba(var(--border-rgb), var(--opacity-light));
+		border-radius: 0.75rem;
+	}
+	.details { display: flex; gap: .75rem; font-size: .85rem; opacity: .85; flex-wrap: wrap; }
+	.badge { padding: .15rem .5rem; border-radius: 999px; text-transform: capitalize; }
+	.badge-enabled { background: rgba(40, 180, 99, .25); }
+	.badge-disabled { background: rgba(120, 120, 120, .25); }
+	.badge-loading { background: rgba(255, 193, 7, .25); }
+	.badge-error { background: rgba(220, 53, 69, .25); }
+	.controls { display: flex; gap: .5rem; align-items: center; }
+	.error { color: #ef4444; font-size: .85rem; margin-top: .25rem; }
+</style>


### PR DESCRIPTION
### Motivation
- Provide a frontend runtime that consumes server-provided plugin metadata and renders enabled plugin extensions (sidebar, commands, channel views) so plugins can surface UI features in the app.
- Allow administrators to inspect installed plugins, toggle enable/disable, and request backend/frontend reloads while keeping frontend state synchronized with the backend plugin API.

### Description
- Add runtime types and manifest shape in `frontend/src/lib/plugins/manifest.ts` to mirror backend manifest fields used by the UI.
- Add a minimal plugin API client in `frontend/src/lib/plugins/api.ts` to call `GET /api/plugins`, `POST /api/plugins/:id/enable`, `POST /api/plugins/:id/disable`, and `POST /api/plugins/:id/reload` with auth header support.
- Implement a Svelte registry store `frontend/src/lib/plugins/registry.ts` that supports register/unregister, enable/disable/reload, dynamic `import()` boundaries for plugin frontend bundles, per-plugin load-error state, and extension resolution helpers for `sidebar`, `commands`, and `channelViews`.
- Add a host component `frontend/src/lib/components/plugins/PluginSlot.svelte` that renders resolved extensions and shows a fail-safe fallback UI when an extension fails to load.
- Wire plugin hosts into the app by integrating `PluginSlot` into `frontend/src/lib/components/MainLayout.svelte` (sidebar and channel-view slots).
- Add an admin plugin controls page at `frontend/src/routes/admin/plugins/+page.svelte` showing installed plugins, status badges, enable/disable toggle, reload action, and load-error details.

### Testing
- Ran `npm run check` (type/compile checks); this failed due to existing, pre-existing TypeScript/Svelte issues across the repo that are unrelated to these new plugin modules.  The new plugin files were added and type usages were adjusted where necessary.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and visited `/admin/plugins` to verify the admin UI renders; captured a screenshot of the page to validate runtime rendering (artifact captured during verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ea151b58832aae4c6fd3e3d135a3)