### PR TITLE
Add ban appeal workflow for restricted accounts

### DIFF
--- a/backend/src/api/authRoutes.ts
+++ b/backend/src/api/authRoutes.ts
@@ -5,6 +5,8 @@ import { settingsRepository } from '../db/repositories/settingsRepository.js';
 import { encryptionKeyRepository } from '../db/repositories/encryptionKeyRepository.js';
 import { hashPassword, verifyPassword } from '../auth/passwordHash.js';
 import { generateToken, verifyToken } from '../auth/jwt.js';
+import { banAppealRepository } from '../db/repositories/banAppealRepository.js';
+import { getAppealCooldownInfo } from './banAppealRoutes.js';
 
 // Get authenticated user ID from request
 function getAuthenticatedUserId(req: IncomingMessage): number | null {
@@ -256,6 +258,21 @@ export async function handleLogin(req: IncomingMessage, res: ServerResponse): Pr
 
 		console.log('[Auth] User found:', user.user_id, user.username);
 
+		if (user.is_active === 0) {
+			const latestAppeal = banAppealRepository.getLatestForUser(user.user_id!);
+			const cooldown = getAppealCooldownInfo(user.user_id!);
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({
+				error: 'This account is restricted. You can submit a ban appeal from the login screen.',
+				errorCode: 'account_restricted',
+				canAppeal: cooldown.canAppeal,
+				nextAppealAt: cooldown.nextAppealAt,
+				latestAppealStatus: latestAppeal?.status || null,
+				latestDecisionNote: latestAppeal?.decision_note || null
+			}));
+			return;
+		}
+
 		// Verify password
 		const isValid = await verifyPassword(password, user.password_hash);
 		console.log('[Auth] Password verification result:', isValid);
@@ -290,6 +307,9 @@ export async function handleLogin(req: IncomingMessage, res: ServerResponse): Pr
 		res.end(
 			JSON.stringify({
 				token,
+				notice: banAppealRepository.getLatestForUser(user.user_id!)?.status === 'approved'
+					? 'Your ban appeal has been approved. Welcome back.'
+					: undefined,
 				user: {
 					id: user.user_id,
 					username: user.username,

--- a/backend/src/api/banAppealRoutes.ts
+++ b/backend/src/api/banAppealRoutes.ts
@@ -1,0 +1,212 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { verifyToken } from '../auth/jwt.js';
+import { verifyPassword } from '../auth/passwordHash.js';
+import { getUserRoles } from '../auth/roleMiddleware.js';
+import { banAppealRepository } from '../db/repositories/banAppealRepository.js';
+import { sessionRepository } from '../db/repositories/sessionRepository.js';
+import { userRepository } from '../db/repositories/userRepository.js';
+
+function parseBody(req: IncomingMessage): Promise<Record<string, any>> {
+	return new Promise((resolve, reject) => {
+		let body = '';
+		req.on('data', (chunk: any) => {
+			body += chunk.toString();
+		});
+		req.on('end', () => {
+			try {
+				resolve(body ? JSON.parse(body) : {});
+			} catch {
+				reject(new Error('Invalid JSON'));
+			}
+		});
+		req.on('error', reject);
+	});
+}
+
+function getAuthedUserId(req: IncomingMessage): number | null {
+	const authHeader = req.headers.authorization;
+	if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+
+	try {
+		const payload = verifyToken(authHeader.slice(7));
+		const dbSession = sessionRepository.findById(payload.sessionId);
+		if (!dbSession || (dbSession.expires_at && dbSession.expires_at < Date.now())) return null;
+		return payload.userId;
+	} catch {
+		return null;
+	}
+}
+
+function getAppealCooldownInfo(userId: number): { canAppeal: boolean; nextAppealAt: number | null } {
+	const latestAppeal = banAppealRepository.getLatestForUser(userId);
+	if (!latestAppeal) return { canAppeal: true, nextAppealAt: null };
+	if (latestAppeal.status === 'pending') return { canAppeal: false, nextAppealAt: null };
+
+	if (latestAppeal.status === 'denied') {
+		const note = latestAppeal.decision_note || '';
+		const match = note.match(/cooldown:(\d+)/i);
+		if (match && latestAppeal.reviewed_at) {
+			const cooldownMs = parseInt(match[1], 10) * 1000;
+			const nextAppealAt = latestAppeal.reviewed_at + cooldownMs;
+			if (nextAppealAt > Date.now()) {
+				return { canAppeal: false, nextAppealAt };
+			}
+		}
+	}
+
+	return { canAppeal: true, nextAppealAt: null };
+}
+
+export async function handleSubmitBanAppeal(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const body = await parseBody(req);
+		const username = String(body.username || '').trim();
+		const password = String(body.password || '');
+		const message = String(body.message || '').trim();
+
+		if (!username || !password || message.length < 10) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Username, password, and a message (10+ chars) are required' }));
+			return;
+		}
+
+		const user = userRepository.findByHandleOrUsername(username);
+		if (!user) {
+			res.writeHead(401, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Invalid credentials' }));
+			return;
+		}
+
+		const ok = await verifyPassword(password, user.password_hash);
+		if (!ok) {
+			res.writeHead(401, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Invalid credentials' }));
+			return;
+		}
+
+		if (user.is_active !== 0) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Your account is not currently restricted' }));
+			return;
+		}
+
+		const cooldown = getAppealCooldownInfo(user.user_id!);
+		if (!cooldown.canAppeal) {
+			res.writeHead(429, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({
+				error: 'Appeal cooldown active. Please wait before submitting another appeal.',
+				nextAppealAt: cooldown.nextAppealAt
+			}));
+			return;
+		}
+
+		banAppealRepository.clearPendingForUser(user.user_id!);
+		const appeal = banAppealRepository.create({ user_id: user.user_id!, message });
+
+		res.writeHead(201, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ success: true, appeal }));
+	} catch (error) {
+		console.error('[BanAppeal] Submit error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to submit appeal' }));
+	}
+}
+
+export async function handleGetBanAppeals(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const userId = getAuthedUserId(req);
+		if (!userId) {
+			res.writeHead(401, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Authentication required' }));
+			return;
+		}
+
+		const roles = getUserRoles(userId);
+		if (!roles.some(role => ['owner', 'admin', 'mod'].includes(role))) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Moderator access required' }));
+			return;
+		}
+
+		const pending = banAppealRepository.getPending().map((appeal) => ({
+			...appeal,
+			user: userRepository.findById(appeal.user_id)
+				? {
+					user_id: appeal.user_id,
+					username: userRepository.findById(appeal.user_id)!.username,
+					handle: userRepository.findById(appeal.user_id)!.handle
+				}
+				: null
+		}));
+
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ appeals: pending }));
+	} catch (error) {
+		console.error('[BanAppeal] List error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to fetch appeals' }));
+	}
+}
+
+export async function handleReviewBanAppeal(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const reviewerId = getAuthedUserId(req);
+		if (!reviewerId) {
+			res.writeHead(401, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Authentication required' }));
+			return;
+		}
+
+		const roles = getUserRoles(reviewerId);
+		if (!roles.some(role => ['owner', 'admin', 'mod'].includes(role))) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Moderator access required' }));
+			return;
+		}
+
+		const body = await parseBody(req);
+		const appealId = Number(body.appealId);
+		const decision = body.decision === 'approved' ? 'approved' : body.decision === 'denied' ? 'denied' : null;
+		const decisionNote = String(body.decisionNote || '').trim();
+		const cooldownSeconds = Number(body.cooldownSeconds || 0);
+
+		if (!appealId || !decision) {
+			res.writeHead(400, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'appealId and valid decision are required' }));
+			return;
+		}
+
+		const appeal = banAppealRepository.findById(appealId);
+		if (!appeal || appeal.status !== 'pending') {
+			res.writeHead(404, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: 'Pending appeal not found' }));
+			return;
+		}
+
+		let finalDecisionNote = decisionNote;
+		if (decision === 'denied' && cooldownSeconds > 0) {
+			finalDecisionNote = `${decisionNote}${decisionNote ? ' ' : ''}[cooldown:${cooldownSeconds}]`;
+		}
+
+		banAppealRepository.updateDecision(appealId, {
+			status: decision,
+			reviewed_by: reviewerId,
+			decision_note: finalDecisionNote
+		});
+
+		if (decision === 'approved') {
+			userRepository.update(appeal.user_id, { is_active: 1 });
+		} else {
+			userRepository.update(appeal.user_id, { is_active: 0 });
+		}
+
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ success: true }));
+	} catch (error) {
+		console.error('[BanAppeal] Review error:', error);
+		res.writeHead(500, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ error: 'Failed to review appeal' }));
+	}
+}
+
+export { getAppealCooldownInfo };

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -156,6 +156,39 @@ function runMigrations() {
 	} catch (e) {
 		// Columns may already exist
 	}
+
+	// Migration: Add restriction_reason column to users
+	try {
+		const cols = db.pragma('table_info(users)') as { name: string }[];
+		if (!cols.some(c => c.name === 'restriction_reason')) {
+			db.exec('ALTER TABLE users ADD COLUMN restriction_reason TEXT');
+			console.log('[Database] Migration: added restriction_reason to users');
+		}
+	} catch (e) {
+		// Column may already exist
+	}
+
+	// Migration: Create ban_appeals table for older DBs
+	try {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS ban_appeals (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				user_id INTEGER NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending',
+				message TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				reviewed_by INTEGER,
+				reviewed_at INTEGER,
+				decision_note TEXT,
+				FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+				FOREIGN KEY (reviewed_by) REFERENCES users(user_id) ON DELETE SET NULL
+			)
+		`);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_ban_appeals_user ON ban_appeals(user_id, created_at DESC)');
+		db.exec('CREATE INDEX IF NOT EXISTS idx_ban_appeals_status ON ban_appeals(status, created_at ASC)');
+	} catch (e) {
+		console.error('[Database] Migration error creating ban_appeals table:', e);
+	}
 }
 
 function seedDefaultRoles() {

--- a/backend/src/db/repositories/banAppealRepository.ts
+++ b/backend/src/db/repositories/banAppealRepository.ts
@@ -1,0 +1,74 @@
+import db from '../database.js';
+
+export type BanAppealStatus = 'pending' | 'approved' | 'denied';
+
+export interface BanAppeal {
+	id?: number;
+	user_id: number;
+	status: BanAppealStatus;
+	message: string;
+	created_at: number;
+	reviewed_by?: number | null;
+	reviewed_at?: number | null;
+	decision_note?: string | null;
+}
+
+export class BanAppealRepository {
+	create(data: { user_id: number; message: string }): BanAppeal {
+		const createdAt = Date.now();
+		const stmt = db.prepare(`
+			INSERT INTO ban_appeals (user_id, status, message, created_at)
+			VALUES (?, 'pending', ?, ?)
+		`);
+
+		const info = stmt.run(data.user_id, data.message.trim(), createdAt);
+		return {
+			id: info.lastInsertRowid as number,
+			user_id: data.user_id,
+			status: 'pending',
+			message: data.message.trim(),
+			created_at: createdAt
+		};
+	}
+
+	getLatestForUser(userId: number): BanAppeal | null {
+		const stmt = db.prepare('SELECT * FROM ban_appeals WHERE user_id = ? ORDER BY created_at DESC LIMIT 1');
+		return (stmt.get(userId) as BanAppeal) || null;
+	}
+
+	getPending(): BanAppeal[] {
+		const stmt = db.prepare('SELECT * FROM ban_appeals WHERE status = ? ORDER BY created_at ASC');
+		return stmt.all('pending') as BanAppeal[];
+	}
+
+	getAllByUser(userId: number): BanAppeal[] {
+		const stmt = db.prepare('SELECT * FROM ban_appeals WHERE user_id = ? ORDER BY created_at DESC');
+		return stmt.all(userId) as BanAppeal[];
+	}
+
+	findById(id: number): BanAppeal | null {
+		const stmt = db.prepare('SELECT * FROM ban_appeals WHERE id = ?');
+		return (stmt.get(id) as BanAppeal) || null;
+	}
+
+	updateDecision(id: number, decision: { status: 'approved' | 'denied'; reviewed_by: number; decision_note?: string; reviewed_at?: number }): void {
+		const reviewedAt = decision.reviewed_at ?? Date.now();
+		const stmt = db.prepare(`
+			UPDATE ban_appeals
+			SET status = ?, reviewed_by = ?, reviewed_at = ?, decision_note = ?
+			WHERE id = ?
+		`);
+		stmt.run(decision.status, decision.reviewed_by, reviewedAt, decision.decision_note?.trim() || null, id);
+	}
+
+	clearPendingForUser(userId: number): void {
+		const stmt = db.prepare(`
+			UPDATE ban_appeals
+			SET status = 'denied', reviewed_at = ?, decision_note = COALESCE(decision_note, 'Superseded by newer appeal')
+			WHERE user_id = ? AND status = 'pending'
+		`);
+		stmt.run(Date.now(), userId);
+	}
+}
+
+export const banAppealRepository = new BanAppealRepository();

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -12,7 +12,22 @@ CREATE TABLE IF NOT EXISTS users (
   username_font_family TEXT DEFAULT 'inherit',
   username_font_size TEXT DEFAULT 'inherit',
   username_font_weight TEXT DEFAULT '600',
-  username_font_style TEXT DEFAULT 'normal'
+  username_font_style TEXT DEFAULT 'normal',
+  restriction_reason TEXT
+);
+
+-- Ban appeals
+CREATE TABLE IF NOT EXISTS ban_appeals (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending', -- pending | approved | denied
+  message TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  reviewed_by INTEGER,
+  reviewed_at INTEGER,
+  decision_note TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+  FOREIGN KEY (reviewed_by) REFERENCES users(user_id) ON DELETE SET NULL
 );
 
 -- Unified sessions (temp + registered)
@@ -131,6 +146,8 @@ CREATE INDEX IF NOT EXISTS idx_offline_messages_to_user ON offline_messages(to_u
 CREATE INDEX IF NOT EXISTS idx_offline_messages_expires_at ON offline_messages(expires_at);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_users_handle ON users(handle COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_ban_appeals_user ON ban_appeals(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ban_appeals_status ON ban_appeals(status, created_at ASC);
 CREATE INDEX IF NOT EXISTS idx_user_roles_user ON user_roles(user_id);
 CREATE INDEX IF NOT EXISTS idx_resource_visibility_resource ON resource_visibility(resource_id);
 CREATE INDEX IF NOT EXISTS idx_guest_codes_active ON guest_codes(is_active);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,6 +15,7 @@ import { themeRepository } from "./db/repositories/themeRepository.js";
 import { guestCodeRepository } from "./db/repositories/guestCodeRepository.js";
 import { verifyToken } from "./auth/jwt.js";
 import { handleRegister, handleLogin, handleUpgrade, handleGetUserSettings, handleSaveUserSettings, handleGetPublicKey, handleStoreEncryptionKeys } from "./api/authRoutes.js";
+import { handleGetBanAppeals, handleReviewBanAppeal, handleSubmitBanAppeal } from "./api/banAppealRoutes.js";
 import { handleGetThemePreferences, handleSaveThemePreferences, handleResetThemePreferences } from "./api/themeRoutes.js";
 import { handleGetRelays, handleRelayRegister, handleRelayHealth, handleRelayApprove, handleGetAllRelays } from "./api/relayRoutes.js";
 import { handleGetMediaRuntime, handleMediaGatewayHeartbeat } from "./api/mediaRoutes.js";
@@ -930,6 +931,21 @@ server.on('request', async (req, res) => {
 
   if (url.pathname === "/api/auth/upgrade" && req.method === "POST") {
     await handleUpgrade(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/ban-appeals/submit" && req.method === "POST") {
+    await handleSubmitBanAppeal(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/ban-appeals" && req.method === "GET") {
+    await handleGetBanAppeals(req, res);
+    return;
+  }
+
+  if (url.pathname === "/api/ban-appeals/review" && req.method === "POST") {
+    await handleReviewBanAppeal(req, res);
     return;
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ const SERVER_URL = getServerUrl();
 
 export interface AuthResponse {
 	token: string;
+	notice?: string;
 	user: {
 		id: number;
 		username: string;
@@ -13,6 +14,22 @@ export interface AuthResponse {
 		profilePicture?: string;
 		isRegistered: boolean;
 	};
+}
+
+export interface BanAppeal {
+	id: number;
+	user_id: number;
+	status: 'pending' | 'approved' | 'denied';
+	message: string;
+	created_at: number;
+	reviewed_by?: number | null;
+	reviewed_at?: number | null;
+	decision_note?: string | null;
+	user?: {
+		user_id: number;
+		username: string;
+		handle?: string;
+	} | null;
 }
 
 export async function register(username: string, password: string, handle?: string): Promise<AuthResponse> {
@@ -178,5 +195,54 @@ export async function saveUserSettings(
 		}
 	} finally {
 		clearTimeout(timeout);
+	}
+}
+
+export async function submitBanAppeal(username: string, password: string, message: string): Promise<{ success: boolean; appeal: BanAppeal }> {
+	const res = await fetch(`${SERVER_URL}/api/ban-appeals/submit`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ username, password, message })
+	});
+
+	if (!res.ok) {
+		const error = await res.json();
+		throw new Error(error.error || 'Failed to submit appeal');
+	}
+
+	return res.json();
+}
+
+export async function getPendingBanAppeals(token: string): Promise<BanAppeal[]> {
+	const res = await fetch(`${SERVER_URL}/api/ban-appeals`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (!res.ok) {
+		const error = await res.json();
+		throw new Error(error.error || 'Failed to load ban appeals');
+	}
+
+	const data = await res.json();
+	return data.appeals || [];
+}
+
+export async function reviewBanAppeal(
+	token: string,
+	payload: { appealId: number; decision: 'approved' | 'denied'; decisionNote?: string; cooldownSeconds?: number }
+): Promise<void> {
+	const res = await fetch(`${SERVER_URL}/api/ban-appeals/review`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify(payload)
+	});
+
+	if (!res.ok) {
+		const error = await res.json();
+		throw new Error(error.error || 'Failed to review appeal');
 	}
 }

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import QRCode from 'qrcode';
-	import { register, login, upgradeToRegistered } from '$lib/api';
+	import { register, login, submitBanAppeal, upgradeToRegistered } from '$lib/api';
 	import { initE2E } from '$lib/e2eManager';
 
 	const dispatch = createEventDispatcher<{
@@ -15,6 +15,10 @@
 	let passwordConfirm = '';
 	let error = '';
 	let loading = false;
+	let restrictedLoginPayload: { username: string; password: string } | null = null;
+	let appealMessage = '';
+	let appealStatus = '';
+	let appealSubmitting = false;
 
 	let qrCanvas: HTMLCanvasElement;
 	let showQR = false;
@@ -104,6 +108,9 @@
 		try {
 			const result = await login(username, password);
 			localStorage.setItem('authToken', result.token);
+			if (result.notice) {
+				alert(result.notice);
+			}
 			if (result.user.id) {
 				localStorage.setItem('dbUserId', String(result.user.id));
 				initE2E(result.user.id, result.token, false);
@@ -111,8 +118,36 @@
 			dispatch('login', { username: result.user.username, token: result.token, authMethod: 'registered' });
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Login failed';
+			if (error.toLowerCase().includes('restricted')) {
+				restrictedLoginPayload = { username, password };
+				appealStatus = '';
+			}
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function handleSubmitAppeal() {
+		if (!restrictedLoginPayload) {
+			appealStatus = 'Please attempt login with your restricted account first.';
+			return;
+		}
+
+		if (appealMessage.trim().length < 10) {
+			appealStatus = 'Please provide at least 10 characters.';
+			return;
+		}
+
+		appealSubmitting = true;
+		appealStatus = '';
+		try {
+			await submitBanAppeal(restrictedLoginPayload.username, restrictedLoginPayload.password, appealMessage);
+			appealStatus = 'Appeal submitted. A moderator will review it.';
+			appealMessage = '';
+		} catch (err) {
+			appealStatus = err instanceof Error ? err.message : 'Failed to submit appeal';
+		} finally {
+			appealSubmitting = false;
 		}
 	}
 
@@ -173,6 +208,23 @@
 		{#if error}
 			<div class="error-message">{error}</div>
 		{/if}
+
+		<div class="appeal-panel">
+			<h3>Ban Appeal</h3>
+			<p class="appeal-help">If your account is restricted, log in once, then submit your appeal here.</p>
+			<textarea
+				bind:value={appealMessage}
+				placeholder="Explain why your restriction should be removed"
+				rows="3"
+				disabled={appealSubmitting}
+			></textarea>
+			<button class="join-btn" type="button" on:click={handleSubmitAppeal} disabled={appealSubmitting}>
+				{appealSubmitting ? 'Submitting Appeal...' : 'Submit Appeal'}
+			</button>
+			{#if appealStatus}
+				<div class="appeal-status">{appealStatus}</div>
+			{/if}
+		</div>
 
 		<!-- GUEST TAB -->
 		{#if tab === 'guest'}
@@ -497,6 +549,42 @@
 		border-radius: 8px;
 		margin-bottom: 1rem;
 		font-size: 0.9rem;
+	}
+
+	.appeal-panel {
+		margin: 1rem 0;
+		padding: 0.9rem;
+		border: 1px solid rgba(255,255,255,0.12);
+		border-radius: 10px;
+		text-align: left;
+	}
+
+	.appeal-panel h3 {
+		margin: 0 0 0.5rem;
+		font-size: 0.95rem;
+	}
+
+	.appeal-help {
+		margin: 0 0 0.5rem;
+		font-size: 0.8rem;
+		opacity: 0.8;
+	}
+
+	.appeal-panel textarea {
+		width: 100%;
+		margin-bottom: 0.5rem;
+		padding: 0.6rem;
+		border-radius: 8px;
+		background: rgba(255,255,255,0.06);
+		border: 1px solid rgba(255,255,255,0.1);
+		color: var(--text-primary, #fff);
+		resize: vertical;
+	}
+
+	.appeal-status {
+		margin-top: 0.4rem;
+		font-size: 0.8rem;
+		opacity: 0.95;
 	}
 
 	/* QR Modal */

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -17,6 +17,7 @@
 	import ThemeCustomizer from './ThemeCustomizer.svelte';
 	import UsernameFontCustomizer from './UsernameFontCustomizer.svelte';
 	import UniformFontMode from './UniformFontMode.svelte';
+	import { getPendingBanAppeals, reviewBanAppeal } from '$lib/api';
 	import {
 		getStoredMediaQualityMode,
 		getStoredScreenShareQualityPreset,
@@ -69,6 +70,11 @@
 	let bulkEmojiFileInput: HTMLInputElement;
 	let bulkEmojiFiles: { file: File; name: string; preview: string }[] = [];
 	let uploadingBulk = false;
+	let pendingAppeals: any[] = [];
+	let loadingAppeals = false;
+	let appealNote: Record<number, string> = {};
+	let appealCooldownSeconds: Record<number, number> = {};
+	let canModerateAppeals = false;
 
 	// Load settings from localStorage and enforce server policy
 	onMount(() => {
@@ -88,7 +94,45 @@
 			srtGatewayEnabled = isSrtGatewayEnabled();
 			screenShareQualityPreset = getStoredScreenShareQualityPreset();
 		})();
+
 	});
+
+	$: canModerateAppeals = ['owner', 'admin', 'mod'].includes($currentUser?.highestRole || '');
+	$: if (canModerateAppeals && pendingAppeals.length === 0 && !loadingAppeals && isOpen) {
+		void loadPendingAppeals();
+	}
+
+	async function loadPendingAppeals() {
+		if (!canModerateAppeals) return;
+		const token = localStorage.getItem('authToken');
+		if (!token) return;
+
+		loadingAppeals = true;
+		try {
+			pendingAppeals = await getPendingBanAppeals(token);
+		} catch (error) {
+			console.error('[Settings] Failed to load ban appeals', error);
+		} finally {
+			loadingAppeals = false;
+		}
+	}
+
+	async function handleReviewAppeal(appealId: number, decision: 'approved' | 'denied') {
+		const token = localStorage.getItem('authToken');
+		if (!token) return;
+
+		try {
+			await reviewBanAppeal(token, {
+				appealId,
+				decision,
+				decisionNote: appealNote[appealId] || '',
+				cooldownSeconds: decision === 'denied' ? (appealCooldownSeconds[appealId] || 0) : 0
+			});
+			pendingAppeals = pendingAppeals.filter(a => a.id !== appealId);
+		} catch (error) {
+			alert(error instanceof Error ? error.message : 'Failed to review appeal');
+		}
+	}
 
 	function toggleSound() {
 		soundEnabled = !soundEnabled;
@@ -796,6 +840,31 @@
 					</div>
 				</div>
 
+				{#if canModerateAppeals}
+					<div class="settings-section">
+						<h3>🛡️ Ban Appeals (Moderator)</h3>
+						<button class="action-btn" on:click={loadPendingAppeals} disabled={loadingAppeals}>
+							{loadingAppeals ? 'Refreshing...' : 'Refresh Appeals'}
+						</button>
+						{#if pendingAppeals.length === 0}
+							<p style="margin-top:0.75rem;opacity:0.8;">No pending appeals.</p>
+						{:else}
+							{#each pendingAppeals as appeal (appeal.id)}
+								<div class="appeal-card">
+									<div><strong>{appeal.user?.username || `User #${appeal.user_id}`}</strong> — {new Date(appeal.created_at).toLocaleString()}</div>
+									<div class="appeal-message">{appeal.message}</div>
+									<textarea rows="2" placeholder="Decision note (optional)" bind:value={appealNote[appeal.id]}></textarea>
+									<div class="appeal-actions">
+										<input type="number" min="0" step="60" placeholder="Cooldown seconds" bind:value={appealCooldownSeconds[appeal.id]} />
+										<button class="action-btn" on:click={() => handleReviewAppeal(appeal.id, 'approved')}>Approve</button>
+										<button class="action-btn danger" on:click={() => handleReviewAppeal(appeal.id, 'denied')}>Deny</button>
+									</div>
+								</div>
+							{/each}
+						{/if}
+					</div>
+				{/if}
+
 				<!-- Custom Emojis -->
 				<div class="settings-section">
 					<h3>🎨 Custom Emojis</h3>
@@ -978,6 +1047,36 @@
 		justify-content: center;
 		z-index: 1000;
 		backdrop-filter: blur(4px);
+	}
+
+	.appeal-card {
+		margin-top: 0.75rem;
+		padding: 0.75rem;
+		border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+		border-radius: 10px;
+		background: rgba(255, 255, 255, 0.03);
+	}
+
+	.appeal-message {
+		margin: 0.5rem 0;
+		opacity: 0.95;
+	}
+
+	.appeal-card textarea {
+		width: 100%;
+		margin-bottom: 0.5rem;
+		padding: 0.5rem;
+		border-radius: 8px;
+	}
+
+	.appeal-actions {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.appeal-actions input {
+		max-width: 180px;
 	}
 
 	.modal-content {


### PR DESCRIPTION
### Motivation
- Provide a structured way for users whose accounts are restricted to submit appeals and for moderators to review and act on them.
- Persist appeal data and support cooldowns so repeated appeals can be rate-limited and audited.

### Description
- Database: added `ban_appeals` table and indexes and added `restriction_reason` column to `users`, plus migrations to create/index the table for existing databases (`backend/src/db/schema.sql`, `backend/src/db/database.ts`).
- Backend: implemented a `BanAppealRepository` and HTTP handlers `handleSubmitBanAppeal`, `handleGetBanAppeals`, `handleReviewBanAppeal` to submit, list (moderators), and review appeals (approve/deny + optional cooldown encoded in decision note) (`backend/src/db/repositories/banAppealRepository.ts`, `backend/src/api/banAppealRoutes.ts`).
- Server wiring: exposed endpoints `/api/ban-appeals/submit`, `/api/ban-appeals`, `/api/ban-appeals/review` in the main HTTP router (`backend/src/server.ts`).
- Auth/login: login now blocks restricted accounts with a clear error and appeal metadata (`errorCode: 'account_restricted'`, cooldown info) and returns a welcome notice on login if the most recent appeal was approved (`backend/src/api/authRoutes.ts`).
- Frontend API: added helpers `submitBanAppeal`, `getPendingBanAppeals`, `reviewBanAppeal` and a `BanAppeal` type to `frontend/src/lib/api.ts`.
- UI: added a “Ban Appeal” panel on the login screen so restricted users can submit appeal text after a restricted login attempt (`frontend/src/lib/components/Login.svelte`), and added a moderator review panel in Settings with approve/deny controls, decision notes and optional cooldown seconds (`frontend/src/lib/components/Settings.svelte`).

### Testing
- Ran `cd backend && npm run build` and the backend build completed successfully.
- Ran `cd frontend && npm run build` and the frontend production build completed successfully; a screenshot of the login screen with the Ban Appeal panel was captured during a dev preview.
- Ran `cd frontend && npm run check` which reported pre-existing Svelte/TS/a11y diagnostics unrelated to this feature; these warnings/errors are repository-wide and not introduced by this PR (the feature-specific builds succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e055e444832aae0b4b182786f60f)