### PR TITLE
Add permission-gated plugin context, manifest validation, and handler permission checks

### DIFF
--- a/backend/src/plugins/loader.ts
+++ b/backend/src/plugins/loader.ts
@@ -7,10 +7,28 @@ import fs from 'fs';
 import path from 'path';
 import type { Server, Socket } from 'socket.io';
 import type { Server as HttpServer } from 'http';
-import type { BackendPlugin, PluginContext, PluginManifest, PluginStorage } from './types';
+import {
+  PLUGIN_PERMISSIONS,
+  type BackendPlugin,
+  type PluginContext,
+  type PluginManifest,
+  type PluginPermission,
+  type PluginStorage
+} from './types';
+
+const VALID_PLUGIN_PERMISSIONS = new Set<PluginPermission>(Object.values(PLUGIN_PERMISSIONS));
+
+type LoadedPlugin = {
+  plugin: BackendPlugin;
+  manifest: PluginManifest;
+  permissions: Set<PluginPermission>;
+  status: 'active' | 'error';
+  errors: string[];
+};
 
 export class PluginLoader {
-  private plugins: Map<string, { plugin: BackendPlugin; manifest: PluginManifest }> = new Map();
+  private plugins: Map<string, LoadedPlugin> = new Map();
+  private pluginStatuses: Map<string, { id: string; name: string; version: string; description: string; status: 'active' | 'error'; errors: string[] }> = new Map();
   private pluginsDir: string;
   private storageDir: string;
 
@@ -78,6 +96,7 @@ export class PluginLoader {
         return;
       }
 
+      const permissions = this.validateAndNormalizePermissions(manifest);
       const backendEntry = path.join(pluginPath, manifest.backend.entry);
 
       if (!fs.existsSync(backendEntry)) {
@@ -89,10 +108,12 @@ export class PluginLoader {
       const pluginModule = await import(backendEntry);
       const plugin: BackendPlugin = pluginModule.default || pluginModule;
 
-      const ctx = this.createContext(pluginId);
+      const ctx = this.createContext(pluginId, permissions);
 
       // Initialize plugin
       await plugin.onLoad?.(ctx);
+
+      const pluginErrors: string[] = [];
 
       // Register socket handlers
       this.io.on('connection', (socket: Socket) => {
@@ -101,6 +122,18 @@ export class PluginLoader {
         // Register custom socket events
         if (plugin.socketHandlers) {
           for (const [event, handler] of Object.entries(plugin.socketHandlers)) {
+            const requiredPermissions = manifest.backend?.socketEventPermissions?.[event] ?? [];
+            const missingPermission = requiredPermissions.find(permission => !permissions.has(permission));
+
+            if (missingPermission) {
+              const error = `Socket handler "${event}" denied: missing permission ${missingPermission}`;
+              if (!pluginErrors.includes(error)) {
+                pluginErrors.push(error);
+                console.warn(`⚠️  Plugin ${pluginId}: ${error}`);
+              }
+              continue;
+            }
+
             socket.on(event, (data: any) => {
               try {
                 handler(socket, data, ctx);
@@ -122,7 +155,17 @@ export class PluginLoader {
         console.warn(`  ⚠️  Plugin ${manifest.name} defines routes but Express is not available`);
       }
 
-      this.plugins.set(pluginId, { plugin, manifest });
+      const status: LoadedPlugin = {
+        plugin,
+        manifest,
+        permissions,
+        status: pluginErrors.length > 0 ? 'error' : 'active',
+        errors: pluginErrors
+      };
+
+      this.plugins.set(pluginId, status);
+      this.setPluginStatus(pluginId, manifest, status.status, pluginErrors);
+
       console.log(`✅ Loaded plugin: ${manifest.name} v${manifest.version}`);
 
       // Log registered socket events
@@ -131,48 +174,148 @@ export class PluginLoader {
       }
 
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
       console.error(`❌ Failed to load plugin ${pluginId}:`, error);
+
+      const fallbackManifest = this.readManifestBestEffort(pluginId);
+      if (fallbackManifest) {
+        this.setPluginStatus(pluginId, fallbackManifest, 'error', [message]);
+      }
     }
   }
 
   handleNewConnection(socket: Socket) {
-    for (const [pluginId, { plugin }] of this.plugins.entries()) {
-        const ctx = this.createContext(pluginId);
+    for (const [pluginId, loaded] of this.plugins.entries()) {
+      const { plugin, permissions, manifest, errors } = loaded;
+      const ctx = this.createContext(pluginId, permissions);
 
-        plugin.onConnection?.(socket, ctx);
+      plugin.onConnection?.(socket, ctx);
 
-        if (plugin.socketHandlers) {
-            for (const [event, handler] of Object.entries(plugin.socketHandlers)) {
-                socket.on(event, (data: any) => {
-                    try {
-                        handler(socket, data, ctx);
-                    } catch (error) {
-                        console.error(`❌ Error in plugin ${pluginId} handling ${event}:`, error);
-                    }
-                });
+      if (plugin.socketHandlers) {
+        for (const [event, handler] of Object.entries(plugin.socketHandlers)) {
+          const requiredPermissions = manifest.backend?.socketEventPermissions?.[event] ?? [];
+          const missingPermission = requiredPermissions.find(permission => !permissions.has(permission));
+
+          if (missingPermission) {
+            const error = `Socket handler "${event}" denied: missing permission ${missingPermission}`;
+            if (!errors.includes(error)) {
+              errors.push(error);
             }
-        }
+            continue;
+          }
 
-        socket.on('disconnect', () => {
-            plugin.onDisconnect?.(socket, ctx);
-        });
+          socket.on(event, (data: any) => {
+            try {
+              handler(socket, data, ctx);
+            } catch (error) {
+              console.error(`❌ Error in plugin ${pluginId} handling ${event}:`, error);
+            }
+          });
+        }
+      }
+
+      socket.on('disconnect', () => {
+        plugin.onDisconnect?.(socket, ctx);
+      });
     }
   }
 
+  private createContext(pluginId: string, permissions: Set<PluginPermission>): PluginContext {
+    const hasPermission = (permission: PluginPermission): boolean => permissions.has(permission);
 
-  private createContext(pluginId: string): PluginContext {
     return {
       io: this.io,
       httpServer: this.httpServer,
-      channels: this.context.channels,
-      users: this.context.users,
-      channelMessages: this.context.channelMessages,
+      users: hasPermission(PLUGIN_PERMISSIONS.USERS_READ)
+        ? {
+          list: () => Array.from(this.context.users.values()),
+          getBySocketId: (socketId: string) => this.context.users.get(socketId) || null
+        }
+        : undefined,
+      channels: hasPermission(PLUGIN_PERMISSIONS.CHANNELS_READ) || hasPermission(PLUGIN_PERMISSIONS.CHANNELS_MANAGE)
+        ? {
+          list: () => Array.from(this.context.channels.values()),
+          getById: (channelId: string) => this.context.channels.get(channelId) || null
+        }
+        : undefined,
+      messages: hasPermission(PLUGIN_PERMISSIONS.MESSAGES_READ)
+        ? {
+          listByChannel: (channelId: string) => this.context.channelMessages.get(channelId) || []
+        }
+        : undefined,
       storage: this.createPluginStorage(pluginId),
-      emit: (event: string, data: any) => this.io.emit(event, data),
-      emitToChannel: (channelId: string, event: string, data: any) => {
-        this.context.emitToChannel(channelId, event, data);
-      }
+      emit: hasPermission(PLUGIN_PERMISSIONS.EVENTS_EMIT)
+        ? (event: string, data: any) => this.io.emit(event, data)
+        : undefined,
+      emitToChannel: hasPermission(PLUGIN_PERMISSIONS.EVENTS_EMIT)
+        ? (channelId: string, event: string, data: any) => {
+          this.context.emitToChannel(channelId, event, data);
+        }
+        : undefined,
+      hasPermission
     };
+  }
+
+  private validateAndNormalizePermissions(manifest: PluginManifest): Set<PluginPermission> {
+    const requestedPermissions = manifest.permissions ?? [];
+    const invalidPermissions = requestedPermissions.filter((permission: unknown) => {
+      if (typeof permission !== 'string') {
+        return true;
+      }
+
+      if (!/^[a-z]+\.[a-z]+$/.test(permission)) {
+        return true;
+      }
+
+      return !VALID_PLUGIN_PERMISSIONS.has(permission as PluginPermission);
+    });
+
+    if (invalidPermissions.length > 0) {
+      throw new Error(`Plugin ${manifest.id} requested unknown or unsafe permissions: ${invalidPermissions.join(', ')}`);
+    }
+
+    const socketEventPermissions = manifest.backend?.socketEventPermissions ?? {};
+    for (const [event, permissions] of Object.entries(socketEventPermissions)) {
+      if (!Array.isArray(permissions)) {
+        throw new Error(`Plugin ${manifest.id} has invalid permission mapping for socket event "${event}"`);
+      }
+
+      const invalidEventPermissions = permissions.filter(permission => !VALID_PLUGIN_PERMISSIONS.has(permission));
+      if (invalidEventPermissions.length > 0) {
+        throw new Error(`Plugin ${manifest.id} requested unknown or unsafe socket event permissions on "${event}": ${invalidEventPermissions.join(', ')}`);
+      }
+    }
+
+    return new Set(requestedPermissions);
+  }
+
+  private readManifestBestEffort(pluginId: string): PluginManifest | null {
+    try {
+      const pluginPath = path.join(this.pluginsDir, pluginId);
+      const manifestPath = path.join(pluginPath, 'plugin.json');
+      if (!fs.existsSync(manifestPath)) {
+        return null;
+      }
+      return JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as PluginManifest;
+    } catch {
+      return null;
+    }
+  }
+
+  private setPluginStatus(
+    id: string,
+    manifest: PluginManifest,
+    status: 'active' | 'error',
+    errors: string[]
+  ) {
+    this.pluginStatuses.set(id, {
+      id,
+      name: manifest.name,
+      version: manifest.version,
+      description: manifest.description,
+      status,
+      errors
+    });
   }
 
   private createPluginStorage(pluginId: string): PluginStorage {
@@ -213,9 +356,9 @@ export class PluginLoader {
 
   // Hook methods for core to call
   async triggerOnMessage(channelId: string, message: any) {
-    for (const [pluginId, { plugin }] of this.plugins.entries()) {
+    for (const [pluginId, { plugin, permissions }] of this.plugins.entries()) {
       try {
-        await plugin.onMessage?.(channelId, message, this.createContext(pluginId));
+        await plugin.onMessage?.(channelId, message, this.createContext(pluginId, permissions));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onMessage:`, error);
       }
@@ -223,9 +366,9 @@ export class PluginLoader {
   }
 
   async triggerOnChannelCreate(channel: any) {
-    for (const [pluginId, { plugin }] of this.plugins.entries()) {
+    for (const [pluginId, { plugin, permissions }] of this.plugins.entries()) {
       try {
-        await plugin.onChannelCreate?.(channel, this.createContext(pluginId));
+        await plugin.onChannelCreate?.(channel, this.createContext(pluginId, permissions));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onChannelCreate:`, error);
       }
@@ -233,9 +376,9 @@ export class PluginLoader {
   }
 
   async triggerOnUserJoin(user: any) {
-    for (const [pluginId, { plugin }] of this.plugins.entries()) {
+    for (const [pluginId, { plugin, permissions }] of this.plugins.entries()) {
       try {
-        await plugin.onUserJoin?.(user, this.createContext(pluginId));
+        await plugin.onUserJoin?.(user, this.createContext(pluginId, permissions));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onUserJoin:`, error);
       }
@@ -243,9 +386,9 @@ export class PluginLoader {
   }
 
   async triggerOnUserLeave(userId: string) {
-    for (const [pluginId, { plugin }] of this.plugins.entries()) {
+    for (const [pluginId, { plugin, permissions }] of this.plugins.entries()) {
       try {
-        await plugin.onUserLeave?.(userId, this.createContext(pluginId));
+        await plugin.onUserLeave?.(userId, this.createContext(pluginId, permissions));
       } catch (error) {
         console.error(`Error in plugin ${plugin.name} onUserLeave:`, error);
       }
@@ -253,11 +396,6 @@ export class PluginLoader {
   }
 
   getLoadedPlugins() {
-    return Array.from(this.plugins.entries()).map(([id, { manifest }]) => ({
-      id,
-      name: manifest.name,
-      version: manifest.version,
-      description: manifest.description
-    }));
+    return Array.from(this.pluginStatuses.values());
   }
 }

--- a/backend/src/plugins/types.ts
+++ b/backend/src/plugins/types.ts
@@ -1,15 +1,41 @@
 import type { Server, Socket } from 'socket.io';
 import type { Server as HttpServer } from 'http';
 
+export const PLUGIN_PERMISSIONS = {
+  MESSAGES_READ: 'messages.read',
+  MESSAGES_WRITE: 'messages.write',
+  USERS_READ: 'users.read',
+  CHANNELS_READ: 'channels.read',
+  CHANNELS_MANAGE: 'channels.manage',
+  EVENTS_EMIT: 'events.emit'
+} as const;
+
+export type PluginPermission = typeof PLUGIN_PERMISSIONS[keyof typeof PLUGIN_PERMISSIONS];
+
+export interface PluginUsersService {
+  list: () => any[];
+  getBySocketId: (socketId: string) => any | null;
+}
+
+export interface PluginChannelsService {
+  list: () => any[];
+  getById: (channelId: string) => any | null;
+}
+
+export interface PluginMessagesService {
+  listByChannel: (channelId: string) => any[];
+}
+
 export interface PluginContext {
   io: Server;
   httpServer: HttpServer;
-  channels: Map<string, any>;
-  users: Map<string, any>;
-  channelMessages: Map<string, any[]>;
+  users?: PluginUsersService;
+  channels?: PluginChannelsService;
+  messages?: PluginMessagesService;
   storage: PluginStorage;
-  emit: (event: string, data: any) => void;
-  emitToChannel: (channelId: string, event: string, data: any) => void;
+  emit?: (event: string, data: any) => void;
+  emitToChannel?: (channelId: string, event: string, data: any) => void;
+  hasPermission: (permission: PluginPermission) => boolean;
 }
 
 export interface PluginStorage {
@@ -57,6 +83,7 @@ export interface PluginManifest {
   backend?: {
     entry: string;
     socketEvents?: string[];
+    socketEventPermissions?: Record<string, PluginPermission[]>;
   };
 
   frontend?: {
@@ -73,7 +100,7 @@ export interface PluginManifest {
     };
   };
 
-  permissions?: string[];
+  permissions?: PluginPermission[];
   dependencies?: string[];
   enabled?: boolean;
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,7 +29,10 @@ plugins/
 
   "backend": {
     "entry": "./backend/index.ts",
-    "socketEvents": ["event:name"]
+    "socketEvents": ["your:event"],
+    "socketEventPermissions": {
+      "your:event": ["events.emit"]
+    }
   },
 
   "frontend": {
@@ -41,7 +44,9 @@ plugins/
         "component": "./frontend/Panel.svelte"
       }
     }
-  }
+  },
+
+  "permissions": ["events.emit", "users.read"]
 }
 ```
 
@@ -60,7 +65,7 @@ const plugin: BackendPlugin = {
   socketHandlers: {
     'your:event': async (socket, data, ctx) => {
       // Handle socket event
-      ctx.emit('response:event', { result: 'success' });
+      ctx.emit?.('response:event', { result: 'success' });
     }
   },
 
@@ -73,6 +78,39 @@ const plugin: BackendPlugin = {
 export default plugin;
 ```
 
+## 🔐 Permission Model
+
+Plugins are now capability-gated. The backend only exposes context methods/data when the plugin declares matching permissions.
+
+### Available permissions
+
+- `messages.read` — read channel messages through `ctx.messages`.
+- `messages.write` — reserved for future message mutation APIs.
+- `users.read` — read user data through `ctx.users`.
+- `channels.read` — read channel data through `ctx.channels`.
+- `channels.manage` — reserved for future channel mutation APIs.
+- `events.emit` — broadcast events through `ctx.emit` and `ctx.emitToChannel`.
+
+### Context services (permission-gated)
+
+Instead of direct mutable maps, plugins receive narrow service wrappers:
+
+- `ctx.users?.list()`
+- `ctx.users?.getBySocketId(socketId)`
+- `ctx.channels?.list()`
+- `ctx.channels?.getById(channelId)`
+- `ctx.messages?.listByChannel(channelId)`
+- `ctx.emit?.(...)`
+- `ctx.emitToChannel?.(...)`
+- `ctx.hasPermission(permission)`
+
+### Validation and safety
+
+- Unknown permissions are rejected at load time.
+- Unsafe permission formats are rejected at load time.
+- `backend.socketEventPermissions` is validated; unknown entries fail plugin load.
+- If a socket handler requires permissions the plugin did not request, handler registration is denied and surfaced in plugin status/admin APIs.
+
 ## 🔌 Available Hooks
 
 ### Backend Hooks
@@ -84,23 +122,6 @@ export default plugin;
 - `onChannelCreate(channel, ctx)` - Called on channel creation
 - `onUserJoin(user, ctx)` - Called when user joins
 - `socketHandlers` - Custom socket event handlers
-
-### Plugin Context
-
-The `ctx` object provides:
-
-```typescript
-{
-  io: Server,                    // Socket.IO server
-  app: Express,                  // Express app
-  channels: Map<string, any>,    // All channels
-  users: Map<string, any>,       // All users
-  channelMessages: Map<...>,     // All messages
-  storage: PluginStorage,        // Persistent storage
-  emit: (event, data) => void,   // Broadcast to all
-  emitToChannel: (...) => void   // Emit to specific channel
-}
-```
 
 ### Plugin Storage
 
@@ -118,6 +139,22 @@ await ctx.storage.delete('key');
 const keys = await ctx.storage.list();
 ```
 
+## 🔁 Migration Guide for Existing Plugins
+
+If your plugin predates permission gating, migrate as follows:
+
+1. **Update permission naming** to dot notation (`users.read`, not `users:read`).
+2. **Declare required permissions** in `plugin.json > permissions`.
+3. **Add per-socket-handler requirements** in `backend.socketEventPermissions`.
+4. **Replace direct map access**:
+   - `ctx.users.get(id)` → `ctx.users?.getBySocketId(id)`
+   - `ctx.channels.get(id)` → `ctx.channels?.getById(id)`
+   - `ctx.channelMessages.get(id)` → `ctx.messages?.listByChannel(id)`
+5. **Guard emits**:
+   - `ctx.emit(...)` → `ctx.emit?.(...)`
+   - `ctx.emitToChannel(...)` → `ctx.emitToChannel?.(...)`
+6. **Optional safety checks** with `ctx.hasPermission(...)` before using gated APIs.
+
 ## 📊 Example Plugins
 
 ### Agile Tools
@@ -125,20 +162,6 @@ Located in `plugins/agile-tools/`
 - Task management
 - Sprint planning
 - Burndown charts
-
-## 🎯 Performance Impact
-
-### Base App (No Plugins)
-- Bundle: ~130KB
-- Memory: ~20-30MB
-- Features: Chat, channels, DMs
-
-### With All Plugins
-- Bundle: +150KB
-- Memory: +100MB
-- Features: Everything above + calls + tools
-
-**Users only load plugins they enable!**
 
 ## 🚀 Adding Your Plugin
 
@@ -155,32 +178,12 @@ Located in `plugins/agile-tools/`
 - Test with plugin disabled to ensure core works
 - Document your plugin's events and API
 
-## 🎨 UI Extensions
-
-Plugins can extend:
-- **Sidebar panels** - Add new sidebar items
-- **Channel views** - Custom channel types
-- **Commands** - Slash commands like `/task`
-- **Modals** - Pop-up interfaces
-
 ## 🔒 Security Notes
 
 - Plugins run in the same process (no sandboxing yet)
 - Trust plugins you install
 - Review plugin code before enabling
+- Denied permission errors are surfaced in plugin status/admin APIs
 - Disable with `"enabled": false` in plugin.json
-
-## 📝 Plugin Ideas
-
-- Polls & surveys
-- File sharing with preview
-- Code snippet formatting
-- Translation bot
-- Game integration (chess, trivia)
-- Calendar & events
-- Music sharing
-- Drawing board
-- Code collaboration
-- Crypto wallet integration
 
 **The system is yours - build whatever you want!**

--- a/plugins/agile-tools/backend/index.ts
+++ b/plugins/agile-tools/backend/index.ts
@@ -48,7 +48,7 @@ const plugin: BackendPlugin = {
 
   socketHandlers: {
     'task:create': async (socket: Socket, data: Partial<Task>, ctx: PluginContext) => {
-      const user = ctx.users.get(socket.id);
+      const user = ctx.users?.getBySocketId(socket.id);
       if (!user) return;
 
       const task: Task = {
@@ -71,7 +71,7 @@ const plugin: BackendPlugin = {
       await ctx.storage.set('tasks', tasks);
 
       // Broadcast to all users
-      ctx.emit('task:created', task);
+      ctx.emit?.('task:created', task);
 
       console.log(`✅ Task created: ${task.title} by ${user.username}`);
     },
@@ -92,7 +92,7 @@ const plugin: BackendPlugin = {
       };
 
       await ctx.storage.set('tasks', tasks);
-      ctx.emit('task:updated', tasks[taskIndex]);
+      ctx.emit?.('task:updated', tasks[taskIndex]);
 
       console.log(`✏️  Task updated: ${tasks[taskIndex].id}`);
     },
@@ -107,7 +107,7 @@ const plugin: BackendPlugin = {
       }
 
       await ctx.storage.set('tasks', filteredTasks);
-      ctx.emit('task:deleted', { id: data.id });
+      ctx.emit?.('task:deleted', { id: data.id });
 
       console.log(`🗑️  Task deleted: ${data.id}`);
     },
@@ -118,7 +118,7 @@ const plugin: BackendPlugin = {
     },
 
     'sprint:create': async (socket: Socket, data: { name: string }, ctx: PluginContext) => {
-      const user = ctx.users.get(socket.id);
+      const user = ctx.users?.getBySocketId(socket.id);
       if (!user) return;
 
       const sprint: Sprint = {
@@ -134,7 +134,7 @@ const plugin: BackendPlugin = {
       sprints.push(sprint);
       await ctx.storage.set('sprints', sprints);
 
-      ctx.emit('sprint:created', sprint);
+      ctx.emit?.('sprint:created', sprint);
       console.log(`🏃 Sprint created: ${sprint.name}`);
     },
 
@@ -151,7 +151,7 @@ const plugin: BackendPlugin = {
       sprint.startDate = Date.now();
 
       await ctx.storage.set('sprints', sprints);
-      ctx.emit('sprint:started', sprint);
+      ctx.emit?.('sprint:started', sprint);
 
       console.log(`▶️  Sprint started: ${sprint.name}`);
     },

--- a/plugins/agile-tools/plugin.json
+++ b/plugins/agile-tools/plugin.json
@@ -17,7 +17,14 @@
       "sprint:start",
       "sprint:end",
       "burndown:get"
-    ]
+    ],
+    "socketEventPermissions": {
+      "task:create": ["users.read", "events.emit"],
+      "task:update": ["events.emit"],
+      "task:delete": ["events.emit"],
+      "sprint:create": ["users.read", "events.emit"],
+      "sprint:start": ["events.emit"]
+    }
   },
 
   "frontend": {
@@ -34,8 +41,8 @@
   },
 
   "permissions": [
-    "channels:read",
-    "messages:write"
+    "users.read",
+    "events.emit"
   ],
   "dependencies": []
 }


### PR DESCRIPTION
### Motivation

- Limit plugin capabilities by exposing only explicitly-declared APIs to reduce risk of untrusted plugins accessing global in-memory data.
- Provide a clear, typed permission model and per-socket-handler permission metadata so missing capabilities are detected early.
- Surface denied-permission errors in plugin status/admin APIs so operators can see why plugin behavior is restricted.

### Description

- Add concrete permission constants and types in `backend/src/plugins/types.ts` (e.g. `messages.read`, `messages.write`, `users.read`, `channels.read`, `channels.manage`, `events.emit`) and new narrow service interfaces for `users`, `channels`, and `messages`, plus `hasPermission` on `PluginContext`.
- Replace direct `Map` exposures in the plugin context with a permission-gated context factory in `backend/src/plugins/loader.ts` that returns service wrappers and only provides `ctx.emit` / `ctx.emitToChannel` when `events.emit` is granted.
- Validate and normalize `plugin.json` `permissions` and `backend.socketEventPermissions` on load, rejecting unknown/unsafe permission strings and failing plugin status when invalid.
- Check socket handler requirements before registration and deny registration of handlers when required permissions are not granted, recording those denials as plugin errors surfaced via `getLoadedPlugins()` / plugin status.
- Migrate the bundled `agile-tools` plugin to the new model (use `ctx.users?.getBySocketId`, guard `ctx.emit?.(...)`, add `permissions` and `socketEventPermissions` entries) and update `plugins/README.md` with the permission model and a migration guide.

### Testing

- Built the backend to validate types and bundling with `cd backend && npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ea176c4c832aaa01a0e69b0a24c5)