### PR TITLE
Add voice-channel join/leave WebRTC flow and signaling handlers

### DIFF
--- a/frontend/src/lib/calling.ts
+++ b/frontend/src/lib/calling.ts
@@ -81,6 +81,7 @@ const peerConnections = new Map<string, PeerConnectionState>();
 
 // Track call participants for targeted cleanup
 const callParticipants = new Set<string>();
+let activeVoiceChannelId: string | null = null;
 
 // Lazy-loaded RTC config (built on first use, not at module load)
 let rtcConfig: RTCConfiguration | null = null;
@@ -456,6 +457,93 @@ function updateRemoteTrackState(targetId: string, track: MediaStreamTrack, type:
 // Call Functions
 // ============================================================================
 
+async function ensureLocalAudioStream(): Promise<MediaStream> {
+	let stream = get(localStream);
+	if (!stream) {
+		stream = await navigator.mediaDevices.getUserMedia({
+			audio: true,
+			video: false
+		});
+		localStream.set(stream);
+		return stream;
+	}
+
+	const hasActiveAudioTrack = stream.getAudioTracks().some(track => track.readyState === 'live');
+	if (hasActiveAudioTrack) {
+		return stream;
+	}
+
+	const audioStream = await navigator.mediaDevices.getUserMedia({
+		audio: true,
+		video: false
+	});
+	const audioTrack = audioStream.getAudioTracks()[0];
+	if (audioTrack) {
+		stream.addTrack(audioTrack);
+	}
+	return stream;
+}
+
+export async function joinVoiceChannel(socket: Socket, channelId: string) {
+	if (activeVoiceChannelId === channelId) {
+		return get(localStream);
+	}
+
+	if (activeVoiceChannelId && activeVoiceChannelId !== channelId) {
+		await leaveVoiceChannel(socket, activeVoiceChannelId);
+	}
+
+	try {
+		const stream = await ensureLocalAudioStream();
+		activeVoiceChannelId = channelId;
+		isInCall.set(true);
+		isMuted.set(false);
+		isVideoOff.set(true);
+		socket.emit('join-voice-channel', { channelId });
+		return stream;
+	} catch (error) {
+		console.error('Error joining voice channel:', error);
+		handleMediaError(error as DOMException, 'starting');
+		isInCall.set(false);
+		throw error;
+	}
+}
+
+export async function leaveVoiceChannel(socket: Socket, channelId: string) {
+	if (activeVoiceChannelId !== channelId) {
+		socket.emit('leave-voice-channel', { channelId });
+		return;
+	}
+
+	socket.emit('leave-voice-channel', { channelId });
+	activeVoiceChannelId = null;
+
+	const stream = get(localStream);
+	if (stream) {
+		stream.getTracks().forEach(track => track.stop());
+		localStream.set(null);
+	}
+
+	isInCall.set(false);
+	isMuted.set(false);
+	isDeafened.set(false);
+	isVideoOff.set(false);
+
+	const callKeys: string[] = [];
+	peerConnections.forEach((state, key) => {
+		if (state.type === 'call') {
+			callKeys.push(key);
+		}
+	});
+	callKeys.forEach(key => cleanupPeerConnection(key));
+
+	activeCalls.set([]);
+	callParticipants.clear();
+	if (peerConnections.size === 0) {
+		connectionState.set('idle');
+	}
+}
+
 export async function startCall(socket: Socket, targetUserId: string, isVideoCall: boolean = false) {
 	try {
 		const stream = await navigator.mediaDevices.getUserMedia({
@@ -547,6 +635,7 @@ export function endCall(socket: Socket) {
 
 	activeCalls.set([]);
 	callParticipants.clear();
+	activeVoiceChannelId = null;
 	connectionState.set('idle');
 }
 
@@ -892,6 +981,7 @@ export function cleanupAllConnections() {
 
 	peerConnections.clear();
 	callParticipants.clear();
+	activeVoiceChannelId = null;
 
 	// Reset all stores
 	activeCalls.set([]);

--- a/frontend/src/lib/socket-manager.ts
+++ b/frontend/src/lib/socket-manager.ts
@@ -1011,6 +1011,22 @@ class SocketManager {
 			calling.handleCallIceCandidate(data.senderId, data.candidate);
 		});
 
+		sock.on('voice-channel-user-joined', (data: { channelId: string; userId: string; username: string }) => {
+			const me = get(currentUser);
+			if (me?.id === data.userId) {
+				return;
+			}
+
+			console.log(`[SocketManager] Voice participant joined ${data.channelId}: ${data.username}`);
+			calling.createCallOffer(sock, data.userId, data.username)
+				.catch(err => console.error('[SocketManager] voice-channel createCallOffer failed:', err));
+		});
+
+		sock.on('voice-channel-user-left', (data: { channelId: string; userId: string }) => {
+			console.log(`[SocketManager] Voice participant left ${data.channelId}: ${data.userId}`);
+			calling.removeCall(data.userId);
+		});
+
 		sock.on('screen-share-started', (data: { userId: string; username: string }) => {
 			console.log(`[SocketManager] ${data.username} started screen sharing`);
 			sock.emit('request-screen-share', { sharerId: data.userId });
@@ -1269,6 +1285,22 @@ export function switchChannel(channelId: string): void {
 	socketManager.emit('join-channel', channelId);
 	currentChannel.set(channelId);
 	markChannelAsRead(channelId);
+}
+
+export async function joinVoiceChannel(channelId: string): Promise<void> {
+	const sock = socketManager.getSocket();
+	if (!sock) {
+		throw new Error('Socket not connected');
+	}
+	await calling.joinVoiceChannel(sock, channelId);
+}
+
+export async function leaveVoiceChannel(channelId: string): Promise<void> {
+	const sock = socketManager.getSocket();
+	if (!sock) {
+		return;
+	}
+	await calling.leaveVoiceChannel(sock, channelId);
 }
 
 export function createChannel(channelName: string, description?: string): void {


### PR DESCRIPTION
### Motivation
- Provide a channel-based voice calling flow that does not rely on the DM `incomingCall` modal, by acquiring local audio immediately when joining a voice channel and treating the room as an active call session.
- Automatically negotiate peer connections with other participants who join the same voice channel so users can speak/listen without per-user modal acceptance.
- Reuse existing call SDP/ICE helpers and cleanup paths so DM call codepaths remain intact and the new channel flow integrates with current WebRTC plumbing.

### Description
- Added `activeVoiceChannelId` state and an `ensureLocalAudioStream` helper to `frontend/src/lib/calling.ts` to manage/get local audio immediately when needed.
- Implemented `joinVoiceChannel(socket, channelId)` and `leaveVoiceChannel(socket, channelId)` in `calling.ts` to acquire the microphone, set `isInCall`/mute/video defaults, emit join/leave events to the server, and perform cleanup of local media and peer connections on leave.
- Added `voice-channel-user-joined` and `voice-channel-user-left` socket handlers in `frontend/src/lib/socket-manager.ts` that create call offers via `createCallOffer` for new participants and remove call peer state on leaves, and exposed public `joinVoiceChannel`/`leaveVoiceChannel` wrappers on the socket-manager API.
- Kept direct DM call flow (events like `call-incoming`, accept/reject modal behavior and related handlers) unchanged and reused existing `createCallOffer` / `handleCallOffer` / ICE helpers for negotiation and teardown.

### Testing
- Ran `npm run check` (Svelte/TypeScript static checks); the run failed due to many pre-existing, unrelated TypeScript/Svelte errors across the codebase, so overall check returned errors.
- Inspected `svelte-check` output and confirmed the changes to `frontend/src/lib/calling.ts` and `frontend/src/lib/socket-manager.ts` did not introduce new diagnostics in those files during review.
- Performed targeted code review to ensure new APIs and socket listeners call existing signaling helpers (`createCallOffer`, `handleCallOffer`, `handleCallAnswer`, `handleCallIceCandidate`) and that cleanup paths clear `activeVoiceChannelId` and peer connections as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991eb553f00832aad43ba378ad7c172)