### PR TITLE
feat: polish DM surfaces and fix dev runtime

### DIFF
--- a/frontend/src/lib/components/ModeTabsDrawer.css
+++ b/frontend/src/lib/components/ModeTabsDrawer.css
@@ -33,14 +33,14 @@
 	height: 10px;
 	border-radius: 999px;
 	border: 2px solid var(--surface-base, #20222f);
-	box-shadow: 0 2px 8px var(--shadow-md, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.28)));
+	box-shadow: 0 2px 8px var(--shadow-md, rgba(0, 0, 0, 0.28));
 }
 .toggle-indicator-bookmarks { background: color-mix(in srgb, var(--color-warning) 78%, white 22%); }
 .drawer-backdrop {
 	position: fixed;
 	inset: 0;
 	z-index: 1999;
-	background: var(--shadow-sm, var(--shadow-sm, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.3))));
+	background: var(--shadow-sm, rgba(0, 0, 0, 0.3));
 }
 .drawer-panel {
 	position: absolute;
@@ -53,7 +53,7 @@
 	background: var(--surface-base, #20222f);
 	border: 1px solid rgba(var(--text-inverse-rgb, 255, 255, 255), 0.1);
 	border-radius: 12px;
-	box-shadow: 0 12px 32px var(--shadow-md, var(--shadow-md, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.4))));
+	box-shadow: 0 12px 32px var(--shadow-md, rgba(0, 0, 0, 0.4));
 	z-index: 2000;
 	overflow: hidden;
 	display: flex;
@@ -116,7 +116,7 @@
 	width: calc((100% - 0.5rem) / 2);
 	border-radius: 10px;
 	background: linear-gradient(180deg, color-mix(in srgb, var(--accent-primary, var(--color-info, var(--color-info, #6366f1))) 24%, rgba(var(--text-inverse-rgb, 255, 255, 255), 0.08)), color-mix(in srgb, var(--accent-primary, var(--color-info, var(--color-info, #6366f1))) 14%, transparent));
-	box-shadow: inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.1), 0 8px 20px var(--shadow-sm, var(--shadow-md, var(--shadow-md, rgba(0, 0, 0, 0.22)));
+	box-shadow: inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.1), 0 8px 20px var(--shadow-sm, rgba(0, 0, 0, 0.22));
 	transform: translateX(calc(var(--active-section-index, 0) * (100% + 0.25rem)));
 	transition: transform 0.2s ease;
 	pointer-events: none;

--- a/frontend/src/lib/components/ZipPreviewPanel.css
+++ b/frontend/src/lib/components/ZipPreviewPanel.css
@@ -14,7 +14,7 @@
 	border: 1px solid var(--border-subtle, #3a3a3a);
 	border-radius: 8px;
 	padding: 0.5rem;
-	background: var(--shadow-sm, var(--shadow-md, var(--shadow-md, rgba(0, 0, 0, 0.22)));
+	background: var(--shadow-sm, rgba(0, 0, 0, 0.22));
 	max-width: min(92vw, 640px);
 }
 .zip-meta { display: flex; flex-wrap: wrap; gap: 0.65rem; font-size: 0.72rem; color: var(--text-secondary, #b8b8b8); margin-bottom: 0.45rem; }
@@ -58,7 +58,7 @@
 	padding: 0.42rem;
 	border: 1px dashed var(--border-subtle, #3a3a3a);
 	border-radius: 7px;
-	background: var(--shadow-sm, var(--shadow-md, var(--shadow-md, rgba(0, 0, 0, 0.22)));
+	background: var(--shadow-sm, rgba(0, 0, 0, 0.22));
 }
 .zip-inline-text {
 	margin: 0;

--- a/frontend/src/lib/opus-recorder.d.ts
+++ b/frontend/src/lib/opus-recorder.d.ts
@@ -10,7 +10,7 @@ declare module 'opus-recorder' {
     encoderApplication?: number;
   }
 
-  class OpusRecorder {
+  export default class OpusRecorder {
     constructor(config?: OpusRecorderConfig);
     ondataavailable?: (data: ArrayBuffer) => void;
     onpause?: () => void;
@@ -20,6 +20,4 @@ declare module 'opus-recorder' {
     pause(): void;
     resume(): void;
   }
-
-  export { OpusRecorder };
 }

--- a/frontend/src/lib/stdbMediaRelay.ts
+++ b/frontend/src/lib/stdbMediaRelay.ts
@@ -5,7 +5,7 @@
  * Receive: Socket.IO listen → jitter buffer → opus-recorder decoder → AudioWorklet playback
  */
 
-import { OpusRecorder } from 'opus-recorder';
+import OpusRecorder from 'opus-recorder';
 
 export interface StdbMediaRelayConfig {
   sessionId: string;

--- a/frontend/src/styles/components/call-modal-part1.css
+++ b/frontend/src/styles/components/call-modal-part1.css
@@ -23,7 +23,7 @@
 			radial-gradient(circle at 80% 80%, rgba(var(--accent-primary-rgb, 99, 102, 241), 0.18), transparent 50%),
 			var(--surface-base, #111827);
 		border: 1px solid rgba(var(--text-inverse-rgb, 255, 255, 255), 0.1);
-		box-shadow: 0 24px 56px var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.52))));
+		box-shadow: 0 24px 56px var(--shadow-lg, rgba(0, 0, 0, 0.52));
 		border-radius: 20px;
 		padding: 2rem;
 		width: min(420px, 92vw);
@@ -153,7 +153,7 @@
 		border-radius: 12px;
 		background: color-mix(in srgb, var(--surface-base, #111827) 88%, black 12%);
 		border: 1px solid rgba(var(--text-inverse-rgb, 255, 255, 255), 0.12);
-		box-shadow: 0 12px 28px var(--shadow-md, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.42))));
+		box-shadow: 0 12px 28px var(--shadow-md, rgba(0, 0, 0, 0.42));
 	}
 
 	.docked-title {
@@ -257,7 +257,7 @@
 		height: 32px;
 		border-radius: 8px;
 		border: 1px solid rgba(var(--text-inverse-rgb, 255, 255, 255), 0.18);
-		background: var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.52))));
+		background: var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.52)));
 		color: var(--text-inverse, var(--text-inverse, #fff));
 		cursor: pointer;
 		display: flex;
@@ -297,7 +297,7 @@
 		inset: 0.7rem calc(var(--hatch-right) + 0.7rem) 0.7rem calc(var(--hatch-left) + 0.7rem);
 		border-radius: 18px;
 		transform: scale(0.988);
-		box-shadow: 0 16px 40px var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.48))));
+		box-shadow: 0 16px 40px var(--shadow-lg, rgba(0, 0, 0, 0.48));
 	}
 
 	.recording-banner {
@@ -495,7 +495,7 @@
 		left: 0.55rem;
 		bottom: 0.55rem;
 		z-index: 3;
-		background: var(--shadow-lg, var(--shadow-lg, rgba(0, 0, 0, 0.64)));
+		background: var(--shadow-lg, rgba(0, 0, 0, 0.64));
 		color: var(--text-inverse, var(--text-inverse, #fff));
 		padding: 0.25rem 0.45rem;
 		border-radius: 6px;

--- a/frontend/src/styles/components/call-modal-part2.css
+++ b/frontend/src/styles/components/call-modal-part2.css
@@ -6,7 +6,7 @@
 		padding: 0.2rem 0.4rem;
 		border-radius: 999px;
 		border: 1px solid rgba(var(--text-inverse-rgb, 255, 255, 255), 0.24);
-		background: var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56))));
+		background: var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56)));
 		color: var(--text-inverse, var(--text-inverse, #fff));
 		font-size: 0.64rem;
 		font-weight: 700;
@@ -299,7 +299,7 @@
 		top: 0.6rem;
 		left: 50%;
 		transform: translateX(-50%);
-		background: var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.62))));
+		background: var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.62)));
 		padding: 0.35rem 0.6rem;
 		border-radius: 8px;
 		font-size: 0.7rem;
@@ -313,7 +313,7 @@
 		top: 2.2rem;
 		left: 50%;
 		transform: translateX(-50%);
-		background: var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56))));
+		background: var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56)));
 		padding: 0.25rem 0.52rem;
 		border-radius: 8px;
 		font-size: 0.66rem;
@@ -329,7 +329,7 @@
 		left: 50%;
 		transform: translateX(-50%);
 		max-width: min(92vw, 900px);
-		background: var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56))));
+		background: var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.56)));
 		padding: 0.25rem 0.52rem;
 		border-radius: 8px;
 		font-size: 0.66rem;

--- a/frontend/src/styles/components/call-view.css
+++ b/frontend/src/styles/components/call-view.css
@@ -165,7 +165,7 @@
 		border-radius: 8px;
 		overflow: hidden;
 		z-index: 10;
-		box-shadow: 0 4px 12px var(--shadow-sm, var(--shadow-sm, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.3)))));
+		box-shadow: 0 4px 12px var(--shadow-sm, rgba(0, 0, 0, 0.3));
 	}
 
 	.local-video-pip video {

--- a/frontend/src/styles/components/dm-message-view.css
+++ b/frontend/src/styles/components/dm-message-view.css
@@ -277,7 +277,7 @@
 		overflow-y: auto;
 		padding: 0.34rem 0.9rem;
 		border-radius: 999px;
-		background: color-mix(in srgb, var(--surface-raised) 78%, var(--surface-app, var(--surface-app, #000)) 22%);
+		background: color-mix(in srgb, var(--surface-raised) 78%, var(--surface-app, #000) 22%);
 		border: 1px solid color-mix(in srgb, var(--border-subtle) 75%, transparent);
 		box-shadow: inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.05);
 		scrollbar-width: thin;
@@ -401,7 +401,7 @@
 		border: 1px solid var(--border-subtle);
 		border-radius: 8px;
 		padding: 0.35rem;
-		box-shadow: 0 10px 24px var(--shadow-md, var(--shadow-sm, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.24)))));
+		box-shadow: 0 10px 24px var(--shadow-md, rgba(0, 0, 0, 0.24));
 		z-index: 25;
 		display: flex;
 		flex-direction: column;
@@ -427,7 +427,7 @@
 	.mention-suggestion:hover,
 	.mention-suggestion.selected {
 		background: var(--accent-primary);
-		color: var(--text-inverse, var(--text-inverse, #fff));
+		color: var(--text-inverse, #fff);
 	}
 
 	.mention-copy {
@@ -580,7 +580,7 @@
 	.dm-message-view.addon-enabled .dm-msg-text {
 		border-radius: 18px;
 		backdrop-filter: blur(10px);
-		box-shadow: 0 10px 28px var(--shadow-lg, var(--shadow-md, var(--shadow-md, rgba(0, 0, 0, 0.18))));
+		box-shadow: 0 10px 28px var(--shadow-lg, rgba(0, 0, 0, 0.18));
 	}
 
 	.dm-message-view.addon-enabled .dm-msg:not(.own) .dm-msg-text {
@@ -592,7 +592,7 @@
 	.dm-message-view.addon-enabled .dm-msg.own .dm-msg-text {
 		background: rgba(166, 235, 124, var(--line-dm-bubble-opacity, 0.92));
 		color: var(--surface-app, #132012);
-		border-color: var(--shadow-sm, var(--shadow-sm, var(--shadow-sm, rgba(0, 0, 0, 0.08))));
+		border-color: var(--shadow-sm, rgba(0, 0, 0, 0.08));
 	}
 
 	.dm-message-view.addon-enabled .dm-msg-time {
@@ -605,6 +605,188 @@
 
 	.dm-message-view.addon-enabled.preset-line.direct-thread .dm-msg-header {
 		margin-bottom: 0.18rem;
+	}
+
+	/* Frontend polish pass: active DM thread should read like a crafted chat surface. */
+	.dm-message-view {
+		background:
+			radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent-primary) 14%, transparent), transparent 20rem),
+			linear-gradient(180deg, color-mix(in srgb, var(--surface-app) 94%, black 6%), color-mix(in srgb, var(--surface-app) 84%, black 16%));
+	}
+
+	.dm-header {
+		padding: 0.68rem 0.85rem;
+		background: color-mix(in srgb, var(--surface-raised) 78%, transparent);
+		border-bottom-color: color-mix(in srgb, var(--accent-primary) 14%, var(--border-subtle) 86%);
+		box-shadow: 0 8px 28px rgba(0, 0, 0, 0.14), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.04);
+		backdrop-filter: blur(14px);
+	}
+
+	.dm-header-avatar,
+	.dm-header-avatar-placeholder {
+		width: 34px;
+		height: 34px;
+		box-shadow: 0 0 0 1px rgba(var(--text-inverse-rgb, 255, 255, 255), 0.08), 0 8px 18px rgba(0, 0, 0, 0.2);
+	}
+
+	.dm-header-name {
+		font-size: 0.96rem;
+		font-weight: 780;
+		letter-spacing: -0.015em;
+	}
+
+	.dm-header-handle {
+		font-size: 0.73rem;
+		color: color-mix(in srgb, var(--text-secondary) 84%, var(--accent-primary) 16%);
+	}
+
+	.dm-retention-control,
+	.dm-notes-btn,
+	.dm-close-btn {
+		appearance: none;
+		-webkit-appearance: none;
+		border-color: color-mix(in srgb, var(--accent-primary) 14%, var(--border-subtle) 86%);
+		background: color-mix(in srgb, var(--surface-app) 70%, transparent);
+		box-shadow: inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.04);
+	}
+
+	.dm-retention-control {
+		border-radius: 999px;
+		padding: 0 0.58rem;
+	}
+
+	.dm-retention-select {
+		appearance: none;
+		-webkit-appearance: none;
+		padding-right: 0.15rem;
+		caret-color: var(--accent-primary);
+	}
+
+	.dm-notes-btn {
+		border-radius: 999px;
+		font-weight: 650;
+		transition: background 0.16s ease, color 0.16s ease, border-color 0.16s ease;
+	}
+
+	.dm-notes-btn:hover,
+	.dm-notes-btn.active,
+	.dm-close-btn:hover {
+		background: color-mix(in srgb, var(--accent-primary) 13%, var(--surface-raised) 87%);
+		border-color: color-mix(in srgb, var(--accent-primary) 34%, var(--border-subtle) 66%);
+		color: var(--text-heading);
+	}
+
+	.dm-retention-control:focus-within,
+	.dm-notes-btn:focus-visible,
+	.dm-close-btn:focus-visible,
+	.dm-input:focus-visible,
+	.dm-send-btn:focus-visible,
+	.dm-directions-btn:focus-visible,
+	.mention-suggestion:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 22%, transparent), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.06);
+	}
+
+	.dm-messages {
+		padding: 0.85rem 0.9rem;
+		gap: 0.18rem;
+	}
+
+	.dm-empty {
+		margin: 1rem;
+		border: 1px dashed color-mix(in srgb, var(--accent-primary) 22%, var(--border-subtle) 78%);
+		border-radius: 20px;
+		background: color-mix(in srgb, var(--surface-raised) 34%, transparent);
+	}
+
+	.dm-empty p {
+		margin: 0;
+		color: var(--text-secondary);
+	}
+
+	.dm-msg {
+		max-width: min(76ch, 88%);
+		padding: 0.18rem 0;
+	}
+
+	.dm-msg-header {
+		margin: 0 0 0.12rem 0.2rem;
+	}
+
+	.dm-msg.own .dm-msg-header {
+		margin-right: 0.2rem;
+		margin-left: 0;
+	}
+
+	.dm-msg-author {
+		font-size: 0.76rem;
+		font-weight: 760;
+	}
+
+	.dm-msg-time {
+		font-size: 0.66rem;
+		color: color-mix(in srgb, var(--text-secondary) 78%, transparent);
+	}
+
+	.dm-msg-text {
+		padding: 0.46rem 0.88rem;
+		border-radius: 17px;
+		line-height: 1.44;
+		background:
+			linear-gradient(180deg, color-mix(in srgb, var(--surface-raised) 86%, transparent), color-mix(in srgb, var(--surface-raised) 70%, transparent));
+		border-color: color-mix(in srgb, var(--border-subtle) 72%, transparent);
+		box-shadow: 0 8px 22px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.045);
+	}
+
+	.dm-msg.own .dm-msg-text {
+		background:
+			linear-gradient(135deg, color-mix(in srgb, var(--accent-primary) 46%, var(--surface-raised) 54%), color-mix(in srgb, var(--accent-primary) 28%, var(--surface-raised) 72%));
+		border-color: color-mix(in srgb, var(--accent-primary) 44%, var(--border-subtle) 56%);
+	}
+
+	.dm-directions-card {
+		border-radius: 18px;
+		background:
+			radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent-primary) 18%, transparent), transparent 12rem),
+			linear-gradient(160deg, color-mix(in srgb, var(--surface-raised) 90%, transparent), color-mix(in srgb, var(--surface-app) 76%, transparent));
+		box-shadow: 0 14px 34px rgba(0, 0, 0, 0.18), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.05);
+	}
+
+	.dm-input-area {
+		padding: 0.65rem 0.75rem;
+		background: color-mix(in srgb, var(--surface-raised) 80%, transparent);
+		border-top-color: color-mix(in srgb, var(--accent-primary) 14%, var(--border-subtle) 86%);
+		box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.04);
+	}
+
+	.dm-input {
+		min-height: 42px;
+		padding: 0.62rem 0.78rem;
+		border-radius: 14px;
+		font-size: 0.92rem;
+		background: color-mix(in srgb, var(--surface-app) 78%, black 6%);
+		border-color: color-mix(in srgb, var(--accent-primary) 16%, var(--border-subtle) 84%);
+		caret-color: var(--accent-primary);
+	}
+
+	.dm-input:focus-visible {
+		border-color: color-mix(in srgb, var(--accent-primary) 56%, var(--border-subtle) 44%);
+		background: color-mix(in srgb, var(--surface-app) 88%, black 4%);
+	}
+
+	.dm-send-btn {
+		width: 42px;
+		height: 42px;
+		border-radius: 14px;
+		background: linear-gradient(135deg, var(--accent-primary), color-mix(in srgb, var(--accent-primary) 72%, #7dd3fc 28%));
+		box-shadow: 0 10px 26px color-mix(in srgb, var(--accent-primary) 28%, transparent);
+		transition: transform 0.16s ease, opacity 0.16s ease, box-shadow 0.16s ease;
+	}
+
+	.dm-send-btn:hover:not(:disabled) {
+		transform: translateY(-1px);
+		opacity: 1;
+		box-shadow: 0 14px 30px color-mix(in srgb, var(--accent-primary) 34%, transparent);
 	}
 
 	.dm-message-view.addon-enabled.preset-discord .dm-background-scrim {

--- a/frontend/src/styles/components/dm-tab.css
+++ b/frontend/src/styles/components/dm-tab.css
@@ -458,7 +458,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		box-shadow: 0 1px 4px var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.35)));
+		box-shadow: 0 1px 4px var(--shadow-md, rgba(0, 0, 0, 0.35));
 	}
 
 	.dm-conv-status-dot {
@@ -604,3 +604,216 @@
 	}
 
 	.dm-new-avatar-ph, .dm-conv-avatar-ph { background-color: var(--avatar-color, var(--accent-primary)); }
+
+	/* Frontend polish pass: DMs should feel like a deliberate workspace surface, not a raw sidebar list. */
+	.dm-tab {
+		background:
+			radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent-primary) 12%, transparent), transparent 18rem),
+			linear-gradient(180deg, color-mix(in srgb, var(--surface-app) 94%, black 6%), var(--surface-app));
+		color: var(--text-heading);
+	}
+
+	.dm-tab-header {
+		padding: 0.85rem 0.85rem 0.7rem;
+		background: linear-gradient(180deg, color-mix(in srgb, var(--surface-raised) 72%, transparent), transparent);
+		border-bottom-color: color-mix(in srgb, var(--accent-primary) 14%, var(--border-subtle) 86%);
+	}
+
+	.dm-tab-title {
+		color: var(--text-heading);
+		font-size: 0.76rem;
+		font-weight: 780;
+		letter-spacing: 0.09em;
+	}
+
+	.dm-new-btn,
+	.dm-header-menu-btn,
+	.dm-back-btn,
+	.dm-delete-btn,
+	.dm-settings-btn,
+	.dm-conv-action-btn,
+	.dm-conv-close-btn {
+		appearance: none;
+		-webkit-appearance: none;
+		background: color-mix(in srgb, var(--surface-raised) 82%, transparent);
+		border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+		box-shadow: inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.04);
+	}
+
+	.dm-new-btn:hover,
+	.dm-header-menu-btn:hover,
+	.dm-back-btn:hover,
+	.dm-settings-btn:hover,
+	.dm-conv-action-btn:hover {
+		background: color-mix(in srgb, var(--accent-primary) 13%, var(--surface-raised) 87%);
+		border-color: color-mix(in srgb, var(--accent-primary) 32%, var(--border-subtle) 68%);
+		color: var(--text-heading);
+	}
+
+	.dm-new-btn:focus-visible,
+	.dm-header-menu-btn:focus-visible,
+	.dm-back-btn:focus-visible,
+	.dm-delete-btn:focus-visible,
+	.dm-settings-btn:focus-visible,
+	.dm-conv-item:focus-visible,
+	.dm-conv-action-btn:focus-visible,
+	.dm-conv-close-btn:focus-visible,
+	.dm-start-btn:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 24%, transparent), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.06);
+	}
+
+	.dm-new-panel {
+		margin: 0.55rem 0.65rem 0.25rem;
+		padding: 0.65rem;
+		border: 1px solid color-mix(in srgb, var(--accent-primary) 13%, var(--border-subtle) 87%);
+		border-radius: 14px;
+		background: color-mix(in srgb, var(--surface-raised) 64%, transparent);
+		box-shadow: 0 12px 28px rgba(0, 0, 0, 0.14), inset 0 1px 0 rgba(var(--text-inverse-rgb, 255, 255, 255), 0.05);
+	}
+
+	.dm-search {
+		padding: 0.62rem 0.75rem;
+		border-radius: 11px;
+		background: color-mix(in srgb, var(--surface-app) 72%, black 8%);
+		border-color: color-mix(in srgb, var(--accent-primary) 16%, var(--border-subtle) 84%);
+		font-size: 0.88rem;
+		caret-color: var(--accent-primary);
+	}
+
+	.dm-search:focus-visible {
+		outline: none;
+		border-color: color-mix(in srgb, var(--accent-primary) 58%, var(--border-subtle) 42%);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 18%, transparent);
+	}
+
+	.dm-new-user {
+		border-radius: 10px;
+		padding: 0.5rem 0.55rem;
+	}
+
+	.dm-new-user:hover {
+		background: color-mix(in srgb, var(--accent-primary) 11%, transparent);
+	}
+
+	.dm-conversations {
+		padding: 0.55rem 0.5rem 0.75rem;
+	}
+
+	.dm-conv-item {
+		gap: 0.65rem;
+		padding: 0.68rem 0.62rem;
+		border-radius: 16px;
+		border-color: transparent;
+		transition: background 0.16s ease, border-color 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+	}
+
+	.dm-conv-item:hover {
+		transform: translateY(-1px);
+		background:
+			linear-gradient(135deg, color-mix(in srgb, var(--accent-primary) 12%, transparent), transparent),
+			color-mix(in srgb, var(--surface-raised) 56%, transparent);
+		border-color: color-mix(in srgb, var(--accent-primary) 25%, var(--border-subtle) 75%);
+		box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16);
+	}
+
+	.dm-conv-item.selected {
+		background:
+			linear-gradient(135deg, color-mix(in srgb, var(--accent-primary) 20%, transparent), transparent 70%),
+			color-mix(in srgb, var(--surface-raised) 72%, transparent);
+		border-color: color-mix(in srgb, var(--accent-primary) 42%, var(--border-subtle) 58%);
+		box-shadow: inset 3px 0 0 var(--accent-primary), 0 12px 28px rgba(0, 0, 0, 0.18);
+	}
+
+	.dm-conv-item-pinned:not(.selected) {
+		background: color-mix(in srgb, var(--accent-primary) 9%, transparent);
+	}
+
+	.dm-conv-avatar-wrap,
+	.dm-conv-avatar,
+	.dm-conv-avatar-ph {
+		width: 40px;
+		height: 40px;
+	}
+
+	.dm-conv-avatar,
+	.dm-conv-avatar-ph {
+		box-shadow: 0 0 0 1px rgba(var(--text-inverse-rgb, 255, 255, 255), 0.08), 0 8px 20px rgba(0, 0, 0, 0.2);
+	}
+
+	.dm-conv-name {
+		font-size: 0.9rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+	}
+
+	.dm-conv-preview {
+		font-size: 0.78rem;
+		line-height: 1.35;
+		color: color-mix(in srgb, var(--text-secondary) 88%, var(--text-heading) 12%);
+	}
+
+	.dm-conv-time {
+		font-size: 0.68rem;
+		font-weight: 650;
+		color: color-mix(in srgb, var(--text-secondary) 76%, var(--accent-primary) 24%);
+	}
+
+	.dm-conv-pin {
+		padding: 0.1rem 0.32rem;
+		border: 1px solid color-mix(in srgb, var(--accent-primary) 32%, transparent);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+		font-size: 0.56rem;
+	}
+
+	.dm-conv-actions {
+		gap: 0.28rem;
+	}
+
+	.dm-conv-action-btn,
+	.dm-conv-close-btn {
+		width: 25px;
+		height: 25px;
+		border-radius: 9px;
+	}
+
+	.dm-empty-state {
+		margin: 1rem 0.35rem;
+		padding: 2.25rem 1rem;
+		border: 1px dashed color-mix(in srgb, var(--accent-primary) 24%, var(--border-subtle) 76%);
+		border-radius: 18px;
+		background: color-mix(in srgb, var(--surface-raised) 42%, transparent);
+		text-align: center;
+	}
+
+	.dm-empty-state p {
+		margin: 0;
+		color: var(--text-secondary);
+	}
+
+	.dm-start-btn {
+		appearance: none;
+		-webkit-appearance: none;
+		border-radius: 999px;
+		padding: 0.6rem 0.95rem;
+		background: linear-gradient(135deg, var(--accent-primary), color-mix(in srgb, var(--accent-primary) 72%, #7dd3fc 28%));
+		box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-primary) 24%, transparent);
+	}
+
+	.dm-active-header {
+		padding: 0.55rem 0.75rem;
+		background: linear-gradient(180deg, color-mix(in srgb, var(--surface-raised) 80%, transparent), color-mix(in srgb, var(--surface-base) 72%, transparent));
+		border-bottom-color: color-mix(in srgb, var(--accent-primary) 14%, var(--border-subtle) 86%);
+		box-shadow: 0 8px 26px rgba(0, 0, 0, 0.12);
+	}
+
+	.dm-header-title {
+		font-size: 0.94rem;
+		font-weight: 780;
+	}
+
+	.dm-header-pill {
+		padding: 0.22rem 0.48rem;
+		background: color-mix(in srgb, var(--surface-app) 72%, transparent);
+	}

--- a/frontend/src/styles/components/map-workspace-part2.css
+++ b/frontend/src/styles/components/map-workspace-part2.css
@@ -73,7 +73,7 @@
 		border-radius: 999px;
 		background: var(--poi-fill);
 		border: 1px solid var(--poi-border);
-		box-shadow: 0 10px 24px var(--shadow-md, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.28))));
+		box-shadow: 0 10px 24px var(--shadow-md, rgba(0, 0, 0, 0.28));
 	}
 
 	.poi-label {
@@ -81,7 +81,7 @@
 		border-radius: 999px;
 		background: var(--poi-label-bg);
 		border: 1px solid var(--poi-label-border);
-		box-shadow: 0 10px 24px var(--shadow-md, var(--shadow-sm, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.24)))));
+		box-shadow: 0 10px 24px var(--shadow-md, rgba(0, 0, 0, 0.24));
 		font-size: 0.82rem;
 		white-space: nowrap;
 	}
@@ -168,7 +168,7 @@
 		border-radius: 999px;
 		border: 1px solid rgba(191, 214, 254, 0.32);
 		background: rgba(var(--surface-app-rgb, 8, 12, 21), 0.76);
-		box-shadow: 0 8px 18px var(--shadow-sm, var(--shadow-md, var(--shadow-sm, rgba(0, 0, 0, 0.2))));
+		box-shadow: 0 8px 18px var(--shadow-sm, rgba(0, 0, 0, 0.2));
 	}
 
 	.compass-arrow {

--- a/frontend/src/styles/components/reader-tab.css
+++ b/frontend/src/styles/components/reader-tab.css
@@ -230,7 +230,7 @@
 		border: 1px solid var(--reader-border);
 		border-radius: 24px;
 		background: var(--reader-surface);
-		box-shadow: 0 18px 44px var(--shadow-sm, var(--shadow-sm, rgba(0, 0, 0, 0.08)));
+		box-shadow: 0 18px 44px var(--shadow-sm, rgba(0, 0, 0, 0.08));
 		color: inherit;
 	}
 
@@ -296,7 +296,7 @@
 	}
 
 	.reader-document :global(pre) {
-		background: var(--shadow-sm, var(--shadow-sm, rgba(0, 0, 0, 0.08)));
+		background: var(--shadow-sm, rgba(0, 0, 0, 0.08));
 		border-radius: 14px;
 		padding: 0.95rem;
 		overflow-x: auto;
@@ -328,7 +328,7 @@
 		border-radius: 24px;
 		border: 1px solid var(--reader-border);
 		background: var(--reader-surface);
-		box-shadow: 0 16px 40px var(--shadow-sm, var(--shadow-sm, rgba(0, 0, 0, 0.08)));
+		box-shadow: 0 16px 40px var(--shadow-sm, rgba(0, 0, 0, 0.08));
 	}
 
 	.reader-empty-card h3 {
@@ -360,7 +360,7 @@
 		border-radius: 22px;
 		border: 1px solid var(--reader-border);
 		background: var(--reader-surface);
-		box-shadow: 0 20px 50px var(--shadow-lg, var(--shadow-md, var(--shadow-md, rgba(0, 0, 0, 0.18))));
+		box-shadow: 0 20px 50px var(--shadow-lg, rgba(0, 0, 0, 0.18));
 	}
 
 	.reader-import-header,
@@ -508,7 +508,7 @@
 		position: absolute;
 		top: 50%;
 		transform: translateY(-50%);
-		background: var(--shadow-md, var(--shadow-md, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.5)))));
+		background: var(--shadow-md, var(--surface-modal-overlay, rgba(0, 0, 0, 0.5)));
 		border: 1px solid var(--reader-border);
 		border-radius: 50%;
 		width: 48px;
@@ -545,7 +545,7 @@
 		bottom: 1rem;
 		left: 50%;
 		transform: translateX(-50%);
-		background: var(--surface-overlay, var(--shadow-lg, var(--shadow-lg, var(--surface-modal-overlay, rgba(0, 0, 0, 0.6)))));
+		background: var(--surface-overlay, var(--surface-modal-overlay, rgba(0, 0, 0, 0.6)));
 		color: white;
 		padding: 0.4rem 0.8rem;
 		border-radius: 999px;

--- a/frontend/src/styles/components/user-popout.css
+++ b/frontend/src/styles/components/user-popout.css
@@ -56,7 +56,7 @@
 		border-radius: 26px;
 		background: var(--surface-base);
 		padding: 6px;
-		box-shadow: 0 14px 34px var(--shadow-md, var(--shadow-md, var(--shadow-lg, rgba(0, 0, 0, 0.32))));
+		box-shadow: 0 14px 34px var(--shadow-md, rgba(0, 0, 0, 0.32));
 	}
 
 	.popout-avatar,


### PR DESCRIPTION
## Summary
- Restores the audited DM visual polish baseline on a fresh branch from updated main
- Polishes DM list/thread surfaces, controls, focus states, active/pinned/empty states, composer, message bubbles, and action buttons
- Fixes the dev-server runtime import for the CommonJS opus-recorder package
- Cleans malformed nested CSS variable fallbacks that caused esbuild CSS syntax warnings during production build

## Verification
- bun run check: 0 errors, 53 existing warnings
- STATIC_BUILD=1 bun run build: passed
- Dev server reached HTTP 200 after fixing opus-recorder import
- Headless Chromium guest login smoke reached the app shell
- Browser tool itself is still broken in this Hermes session, so full DM visual screenshot coverage was limited; with no backend/users, the runtime showed the quick DM empty state rather than populated DM threads

## Notes
- Preserved the previous dirty tree in stash@{0} and /var/home/Ronin/wabi-backups/pre-main-update-20260602-140424.tar.gz before this branch work
